### PR TITLE
Add region selection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ from cli_ac_menu import show_aircon_menu
 from cli_washerdryer_menu import show_washerdryer_menu
 
 from whirlpool.appliancesmanager import AppliancesManager
-from whirlpool.backendselector import BackendSelector, Brand
+from whirlpool.backendselector import BackendSelector, Brand, Region
 from whirlpool.auth import Auth
 from whirlpool.washerdryer import WasherDryer
 
@@ -23,6 +23,9 @@ parser.add_argument("-p", "--password", help="Password")
 parser.add_argument(
     "-b", "--brand", help="Brand (whirlpool/maytag)", default="whirlpool"
 )
+parser.add_argument(
+    "-r", "--region", help="Region (EU/US)", default="EU"
+)
 parser.add_argument("-l", "--list", help="List appliances", action="store_true")
 parser.add_argument("-s", "--said", help="The appliance to load")
 args = parser.parse_args()
@@ -33,12 +36,22 @@ async def start():
         logger.info("Attributes updated")
 
     if args.brand == "whirlpool":
-        backend_selector = BackendSelector(Brand.Whirlpool)
+        selected_brand = Brand.Whirlpool
     elif args.brand == "maytag":
-        backend_selector = BackendSelector(Brand.Maytag)
+        selected_brand = Brand.Maytag
     else:
         logger.error("Invalid brand argument")
         return
+
+    if args.region == "EU":
+        selected_region = Region.EU
+    elif args.region == "US":
+        selected_region = Region.US
+    else:
+        logger.error("Invalid region argument")
+        return
+
+    backend_selector = BackendSelector(selected_brand, selected_region)
 
     auth = Auth(backend_selector, args.email, args.password)
     await auth.do_auth(store=False)

--- a/tests/mock_backendselector.py
+++ b/tests/mock_backendselector.py
@@ -4,6 +4,10 @@ class BackendSelectorMock:
         return "dummy_brand"
 
     @property
+    def region(self):
+        return "dummy_region"
+
+    @property
     def base_url(self):
         return "dummy_base_url"
 

--- a/whirlpool/backendselector.py
+++ b/whirlpool/backendselector.py
@@ -8,32 +8,45 @@ class Brand(Enum):
     Whirlpool = 0
     Maytag = 1
 
+class Region(Enum):
+    EU = 0
+    US = 1
+
 
 BACKEND_DATA = {
     Brand.Whirlpool: {
-        "base_url": "https://api.whrcloud.eu",
         "client_id": "whirlpool_android",
         "client_secret": "i-eQ8MD4jK4-9DUCbktfg-t_7gvU-SrRstPRGAYnfBPSrHHt5Mc0MFmYymU2E2qzif5cMaBYwFyFgSU6NTWjZg",
     },
     Brand.Maytag: {
-        "base_url": "https://api.whrcloud.com",
         "client_id": "maytag_ios",
         "client_secret": "OfTy3A3rV4BHuhujkPThVDE9-SFgOymJyUrSbixjViATjCGviXucSKq2OxmPWm8DDj9D1IFno_mZezTYduP-Ig",
+    },
+    Region.EU: {
+        "base_url": "https://api.whrcloud.eu"
+    },
+    Region.US: {
+        "base_url": "https://api.whrcloud.com"
     },
 }
 
 
 class BackendSelector:
-    def __init__(self, brand: Brand):
+    def __init__(self, brand: Brand, region: Region):
         self._brand = brand
+        self._region = region
 
     @property
     def brand(self):
         return self._brand
 
     @property
+    def region(self):
+        return self._region
+
+    @property
     def base_url(self):
-        return BACKEND_DATA[self._brand].get("base_url")
+        return BACKEND_DATA[self._region].get("base_url")
 
     @property
     def client_id(self):


### PR DESCRIPTION
This PR:
- Adds a new flag (--region / -r).  I defaulted to EU for backcompat
- Adds region enum and pulls the base URL out of the brand selection and into region selection


Fixes https://github.com/abmantis/whirlpool-sixth-sense/issues/7