### PR TITLE
Update setup.py, exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/abmantis/whirlpool-sixth-sense/",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests","tests.*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
otherwise it would try to install a package called 'tests' at top level:

```
...
running install_scripts
 * ERROR: dev-python/whirlpool-sixth-sense-0.17.1::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 3333:  Called distutils-r1_src_install
 *   environment, line 1577:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  681:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3017:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2580:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2578:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1017:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1540:  Called _distutils-r1_post_python_install
 *   environment, line  581:  Called die
 * The specific snippet of code:
 *                   die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/whirlpool-sixth-sense-0.17.1::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/whirlpool-sixth-sense-0.17.1::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/whirlpool-sixth-sense-0.17.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/whirlpool-sixth-sense-0.17.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/whirlpool-sixth-sense-0.17.1/work/whirlpool_sixth_sense-0.17.1'
 * S: '/var/tmp/portage/dev-python/whirlpool-sixth-sense-0.17.1/work/whirlpool_sixth_sense-0.17.1'

 * Messages for package dev-python/whirlpool-sixth-sense-0.17.1:

 * ERROR: dev-python/whirlpool-sixth-sense-0.17.1::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 3333:  Called distutils-r1_src_install
 *   environment, line 1577:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  681:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3017:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2580:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2578:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1017:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1540:  Called _distutils-r1_post_python_install
 *   environment, line  581:  Called die
 * The specific snippet of code:
 *                   die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
```