### PR TITLE
Forgiving "has_attribute" test

### DIFF
--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -132,7 +132,7 @@ class Appliance:
         return self._data_dict["attributes"][attribute]["value"]
 
     def has_attribute(self, attribute):
-        return attribute in self._data_dict["attributes"]
+        return attribute in self._data_dict.get("attributes")
 
     def bool_to_attr_value(self, b: bool):
         return SETVAL_VALUE_ON if b else SETVAL_VALUE_OFF


### PR DESCRIPTION
Noticed that when unloading integration (or reloading) the has_attribute() function is called with an empty _data_dict or _data_dict is missing "attributes" key.  This causes HA integration unload to hang up.
Since it's trying to verify a key exists - this is probably a better way...