### PR TITLE
Appliance Unregister test for none, retry on data fetch if auth is required.

### DIFF
--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -148,8 +148,8 @@ class Appliance:
     def has_attribute(self, attribute):
         if self._data_dict is None:
             LOGGER.error("No data available")
-            return None
-        return attribute in self._data_dict.get("attributes")
+            return False
+        return attribute in self._data_dict.get("attributes", {})
 
     def bool_to_attr_value(self, b: bool):
         return SETVAL_VALUE_ON if b else SETVAL_VALUE_OFF

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -52,7 +52,7 @@ class Appliance:
     def _event_socket_handler(self, msg):
         json_msg = json.loads(msg)
         timestamp = json_msg["timestamp"]
-        for (attr, val) in json_msg["attributeMap"].items():
+        for attr, val in json_msg["attributeMap"].items():
             if not self.has_attribute(attr):
                 continue
             self._set_attribute(attr, str(val), timestamp)

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -132,7 +132,7 @@ class Appliance:
         return self._data_dict["attributes"][attribute]["value"]
 
     def has_attribute(self, attribute):
-        return attribute in self._data_dict["attributes"]
+        return attribute in self._data_dict.get("attributes")
 
     def bool_to_attr_value(self, b: bool):
         return SETVAL_VALUE_ON if b else SETVAL_VALUE_OFF

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -144,7 +144,7 @@ class Appliance:
         return self._data_dict["attributes"][attribute]["value"]
 
     def has_attribute(self, attribute):
-        if self._data_dict:
+        if self._data_dict is not None:
             return attribute in self._data_dict.get("attributes")
         return None
 

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -106,9 +106,10 @@ class Appliance:
                         self._data_dict = json.loads(await r.text())
                         return True
                     elif r.status == 401:
+                        LOGGER.error("Fetching data failed (%s). Doing reauth", r.status)
                         await self._auth.do_auth()
-
-        LOGGER.error("Fetching data failed (%s)", r.status)
+                    else:
+                        LOGGER.error("Fetching data failed (%s)", r.status)
         return False
 
     async def send_attributes(self, attributes):

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -47,7 +47,8 @@ class Appliance:
                 LOGGER.debug("Unregistered attr callback")
             except ValueError:
                 LOGGER.error("Attr callback not found")
-        LOGGER.error("_attr_changed is None when unregistering callback")
+        else:
+            LOGGER.error("_attr_changed is None when unregistering callback")
 
     def _event_socket_handler(self, msg):
         json_msg = json.loads(msg)

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -144,9 +144,10 @@ class Appliance:
         return self._data_dict["attributes"][attribute]["value"]
 
     def has_attribute(self, attribute):
-        if self._data_dict is not None:
-            return attribute in self._data_dict.get("attributes")
-        return None
+        if self._data_dict is None:
+            LOGGER.error("No data available")
+            return None
+        return attribute in self._data_dict.get("attributes")
 
     def bool_to_attr_value(self, b: bool):
         return SETVAL_VALUE_ON if b else SETVAL_VALUE_OFF

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -35,15 +35,19 @@ class Appliance:
         self._session: aiohttp.ClientSession = session
 
     def register_attr_callback(self, update_callback: Callable):
+        """Register Callback function."""
         self._attr_changed.append(update_callback)
         LOGGER.debug("Registered attr callback")
 
     def unregister_attr_callback(self, update_callback: Callable):
-        try:
-            self._attr_changed.remove(update_callback)
-            LOGGER.debug("Unregistered attr callback")
-        except ValueError:
-            LOGGER.error("Attr callback not found")
+        """Unregister callback function."""
+        if self._attr_changed:
+            try:
+                self._attr_changed.remove(update_callback)
+                LOGGER.debug("Unregistered attr callback")
+            except ValueError:
+                LOGGER.error("Attr callback not found")
+        LOGGER.error("_attr_changed is None when unregistering callback")
 
     def _event_socket_handler(self, msg):
         json_msg = json.loads(msg)

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -100,15 +100,16 @@ class Appliance:
             return False
 
         uri = f"{self._backend_selector.base_url}/api/v1/appliance/{self._said}"
-        async with async_timeout.timeout(30):
-            async with self._session.get(uri, headers=self._create_headers()) as r:
-                self._data_dict = json.loads(await r.text())
-                if r.status == 200:
-                    return True
-                elif r.status == 401:
-                    await self._auth.do_auth()
+        for n in range(3):
+            async with async_timeout.timeout(30):
+                async with self._session.get(uri, headers=self._create_headers()) as r:
+                    if r.status == 200:
+                        self._data_dict = json.loads(await r.text())
+                        return True
+                    elif r.status == 401:
+                        await self._auth.do_auth()
 
-                LOGGER.error(f"Fetching data failed ({r.status})")
+        LOGGER.error("Fetching data failed (%s)", r.status)
         return False
 
     async def send_attributes(self, attributes):

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -99,14 +99,16 @@ class Appliance:
             return False
 
         uri = f"{self._backend_selector.base_url}/api/v1/appliance/{self._said}"
-        for n in range(RETRY_COUNT):
+        for n in range(REQUEST_RETRY_COUNT):
             async with async_timeout.timeout(30):
                 async with self._session.get(uri, headers=self._create_headers()) as r:
                     if r.status == 200:
                         self._data_dict = json.loads(await r.text())
                         return True
                     elif r.status == 401:
-                        LOGGER.error("Fetching data failed (%s). Doing reauth", r.status)
+                        LOGGER.error(
+                            "Fetching data failed (%s). Doing reauth", r.status
+                        )
                         await self._auth.do_auth()
                     else:
                         LOGGER.error("Fetching data failed (%s)", r.status)
@@ -124,7 +126,7 @@ class Appliance:
             "body": attributes,
             "header": {"said": self._said, "command": "setAttributes"},
         }
-        for n in range(RETRY_COUNT):
+        for n in range(REQUEST_RETRY_COUNT):
             async with async_timeout.timeout(30):
                 async with self._session.post(
                     uri, json=cmd_data, headers=self._create_headers()

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -143,7 +143,9 @@ class Appliance:
         return self._data_dict["attributes"][attribute]["value"]
 
     def has_attribute(self, attribute):
-        return attribute in self._data_dict.get("attributes")
+        if self._data_dict:
+            return attribute in self._data_dict.get("attributes")
+        return None
 
     def bool_to_attr_value(self, b: bool):
         return SETVAL_VALUE_ON if b else SETVAL_VALUE_OFF

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -15,7 +15,7 @@ ATTR_ONLINE = "Online"
 
 SETVAL_VALUE_OFF = "0"
 SETVAL_VALUE_ON = "1"
-RETRY_COUNT = 3
+REQUEST_RETRY_COUNT = 3
 
 
 class Appliance:

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -114,6 +114,25 @@ class Appliance:
                         LOGGER.error("Fetching data failed (%s)", r.status)
         return False
 
+    async def check_login(self):
+        """Verify user is logged in, reauth if not logged in"""
+        if not self._session:
+            LOGGER.error("Session not started")
+            return False
+
+        uri = f"{self._backend_selector.base_url}/api/v1/appliance/{self._said}"
+        for retry in range(REQUEST_RETRY_COUNT):
+            async with async_timeout.timeout(30):
+                async with self._session.get(uri, headers=self._create_headers()) as r:
+                    if r.status == 200:
+                        return True
+                    elif r.status == 401:
+                        LOGGER.error("Login check failed (%s). Doing reauth", r.status)
+                        await self._auth.do_auth()
+                    else:
+                        LOGGER.error("Login failed (%s)", r.status)
+        return False
+
     async def send_attributes(self, attributes):
         if not self._session:
             LOGGER.error("Session not started")
@@ -177,6 +196,7 @@ class Appliance:
             self._said,
             self._event_socket_handler,
             self.fetch_data,
+            self.check_login,
             self._session,
         )
         self._event_socket.start()

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import aiohttp
 import asyncio
 import async_timeout
@@ -57,7 +58,7 @@ class Auth:
         with open(AUTH_JSON_FILE, "w") as f:
             json.dump(self._auth_dict, f)
 
-    async def _do_auth(self, refresh_token):
+    async def _do_auth(self, refresh_token: str) -> str | None:
         auth_url = f"{self._backend_selector.base_url}/oauth/token"
         auth_header = {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -101,7 +102,7 @@ class Auth:
                     return await self._do_auth(refresh_token=None)
                 return None
 
-    async def do_auth(self, store=True):
+    async def do_auth(self, store: bool = False) -> bool | None:
         fetched_auth_data = await self._do_auth(
             self._auth_dict.get("refresh_token", None)
         )
@@ -109,7 +110,7 @@ class Auth:
         if not fetched_auth_data:
             self._auth_dict = {}
             LOGGER.error("Authentication failed")
-            return
+            return False
 
         curr_timestamp = datetime.now().timestamp()
         self._auth_dict = {
@@ -122,6 +123,7 @@ class Auth:
         if store:
             self._save_auth_data()
         self._schedule_auto_renewal()
+        return True
 
     async def load_auth_file(self):
         try:

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -102,7 +102,7 @@ class Auth:
                     return await self._do_auth(refresh_token=None)
                 return None
 
-    async def do_auth(self, store: bool = False) -> bool | None:
+    async def do_auth(self, store: bool = False) -> bool:
         fetched_auth_data = await self._do_auth(
             self._auth_dict.get("refresh_token", None)
         )

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import aiohttp
 import asyncio
 import async_timeout

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -1,11 +1,11 @@
-import aiohttp
 from socket import gaierror
+from typing import Callable
 import asyncio
 import logging
 import re
 import uuid
+import aiohttp
 
-from typing import Callable
 
 from .auth import Auth
 
@@ -13,7 +13,8 @@ LOGGER = logging.getLogger(__name__)
 
 MSG_TERMINATION = "\n\n\0"
 
-RECV_MSG_MATCHER = re.compile("{(.*)}\\x00")
+DATA_MSG_MATCHER = re.compile("{(.*)}\\x00")
+TOKEN_INVALID_MSG_MATCHER = re.compile(".*Token Invalid.*")
 
 WS_STATUS_GOING_AWAY = 1001
 WS_STATUS_UNAUTHORIZED = 3000
@@ -25,6 +26,8 @@ GOING_AWAY_DELAY = (60 * 5) - RECONNECT_SHORT_DELAY
 
 
 class EventSocket:
+    """Event socket listener class"""
+
     def __init__(
         self,
         url,
@@ -32,7 +35,6 @@ class EventSocket:
         said,
         msg_listener: Callable[[str], None],
         con_up_listener: Callable,
-        check_login_listener: Callable,
         session: aiohttp.ClientSession,
     ):
         self._url = url
@@ -43,7 +45,6 @@ class EventSocket:
         self._websocket: aiohttp.ClientWebSocketResponse = None
         self._run_future = None
         self._con_up_listener = con_up_listener
-        self._check_login_listener = check_login_listener
         self._reconnect_tries = RECONNECT_COUNT
         self._session = session
 
@@ -77,15 +78,16 @@ class EventSocket:
                     heartbeat=45,
                 ) as ws:
                     self._websocket = ws
-                    await self._check_login_listener()
-                    await self._send_msg(ws, self._create_connect_msg())
-                    await self._recv_msg(ws)
-                    await self._send_msg(ws, self._create_subscribe_msg())
-                    await self._con_up_listener()
-
                     self._reconnect_tries = RECONNECT_COUNT
+                    connected_msg_done = False
+                    subscribe_msg_done = False
 
                     while not ws.closed:
+                        if not connected_msg_done:
+                            await self._send_msg(ws, self._create_connect_msg())
+                        elif not subscribe_msg_done:
+                            await self._send_msg(ws, self._create_subscribe_msg())
+
                         msg = await self._recv_msg(ws)
                         if not msg:
                             continue
@@ -97,7 +99,7 @@ class EventSocket:
                             aiohttp.WSMsgType.CLOSING,
                             aiohttp.WSMsgType.CLOSED,
                         ]:
-                            LOGGER.warn(
+                            LOGGER.warning(
                                 f"Stopping receiving. Message type: {str(msg.type)}"
                             )
 
@@ -110,7 +112,7 @@ class EventSocket:
                                     await asyncio.sleep(RECONNECT_LONG_DELAY)
 
                             elif msg.data == WS_STATUS_GOING_AWAY:
-                                LOGGER.warn(
+                                LOGGER.warning(
                                     f"Received Going Away message: Waiting for {GOING_AWAY_DELAY} seconds"
                                 )
                                 # Give server some time to come back up.
@@ -118,13 +120,31 @@ class EventSocket:
 
                             break
 
+                        invalid_token_match = TOKEN_INVALID_MSG_MATCHER.findall(
+                            msg.data
+                        )
+                        if invalid_token_match:
+                            LOGGER.debug("received invalid token msg, doing reauth now")
+                            while not await self._auth.do_auth():
+                                await asyncio.sleep(RECONNECT_LONG_DELAY)
+                            break
+
+                        if not connected_msg_done:
+                            connected_msg_done = True
+                            continue
+
+                        if not subscribe_msg_done:
+                            subscribe_msg_done = True
+                            await self._con_up_listener()
+                            continue
+
                         if msg.type != aiohttp.WSMsgType.TEXT:
                             LOGGER.error(
                                 f"Socket message type is invalid: {str(msg.type)}"
                             )
                             continue
 
-                        match = RECV_MSG_MATCHER.findall(msg.data)
+                        match = DATA_MSG_MATCHER.findall(msg.data)
                         if not match:
                             continue
                         self._msg_listener("{" + match[0] + "}")
@@ -132,8 +152,8 @@ class EventSocket:
                 aiohttp.ClientError,
                 asyncio.TimeoutError,
                 gaierror,
-            ) as e:
-                LOGGER.error(f"Websocket could not connect: {e}")
+            ) as ex:
+                LOGGER.error(f"Websocket could not connect: {ex}")
 
             self._websocket = None
 
@@ -156,10 +176,12 @@ class EventSocket:
                 LOGGER.info("Reconnecting...")
 
     def start(self):
+        """Start the event socket listener"""
         self._running = True
         self._run_future = asyncio.get_event_loop().create_task(self._run())
 
     async def stop(self):
+        """Stop the event socket listener"""
         self._running = False
         if not self._websocket:
             return

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -104,7 +104,7 @@ class EventSocket:
                             ):
                                 LOGGER.debug("auth key expired, doing reauth now")
                                 while not await self._auth.do_auth():
-                                    asyncio.sleep(RECONNECT_LONG_DELAY)
+                                    await asyncio.sleep(RECONNECT_LONG_DELAY)
 
                             elif msg.data == WS_STATUS_GOING_AWAY:
                                 LOGGER.warn(

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -133,7 +133,6 @@ class EventSocket:
         self._websocket = None
 
         if self._running:
-
             self._reconnect_tries -= 1
             if self._reconnect_tries < 0:
                 self._reconnect_tries = 0

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -32,6 +32,7 @@ class EventSocket:
         said,
         msg_listener: Callable[[str], None],
         con_up_listener: Callable,
+        check_login_listener: Callable,
         session: aiohttp.ClientSession,
     ):
         self._url = url
@@ -42,6 +43,7 @@ class EventSocket:
         self._websocket: aiohttp.ClientWebSocketResponse = None
         self._run_future = None
         self._con_up_listener = con_up_listener
+        self._check_login_listener = check_login_listener
         self._reconnect_tries = RECONNECT_COUNT
         self._session = session
 
@@ -75,10 +77,11 @@ class EventSocket:
                     heartbeat=45,
                 ) as ws:
                     self._websocket = ws
-                    await self._con_up_listener()
+                    await self._check_login_listener()
                     await self._send_msg(ws, self._create_connect_msg())
                     await self._recv_msg(ws)
                     await self._send_msg(ws, self._create_subscribe_msg())
+                    await self._con_up_listener()
 
                     self._reconnect_tries = RECONNECT_COUNT
 

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -62,94 +62,95 @@ class EventSocket:
         return msg
 
     async def _run(self):
-        if not self._running:
-            return
-        timeout = aiohttp.ClientTimeout(total=None, connect=60, sock_connect=60)
+        while self._running:
+            timeout = aiohttp.ClientTimeout(total=None, connect=60, sock_connect=60)
 
-        try:
-            LOGGER.debug(f"Connecting to {self._url}")
-            async with self._session.ws_connect(
-                self._url,
-                timeout=timeout,
-                autoclose=True,
-                autoping=True,
-                heartbeat=45,
-            ) as ws:
-                self._websocket = ws
-                await self._con_up_listener()
-                await self._send_msg(ws, self._create_connect_msg())
-                await self._recv_msg(ws)
-                await self._send_msg(ws, self._create_subscribe_msg())
+            try:
+                LOGGER.debug(f"Connecting to {self._url}")
+                async with self._session.ws_connect(
+                    self._url,
+                    timeout=timeout,
+                    autoclose=True,
+                    autoping=True,
+                    heartbeat=45,
+                ) as ws:
+                    self._websocket = ws
+                    await self._con_up_listener()
+                    await self._send_msg(ws, self._create_connect_msg())
+                    await self._recv_msg(ws)
+                    await self._send_msg(ws, self._create_subscribe_msg())
 
-                self._reconnect_tries = RECONNECT_COUNT
+                    self._reconnect_tries = RECONNECT_COUNT
 
-                while not ws.closed:
-                    msg = await self._recv_msg(ws)
-                    if not msg:
-                        continue
-                    if msg.type == aiohttp.WSMsgType.ERROR:
-                        LOGGER.error("Socket message error")
-                        break
-                    if msg.type in [
-                        aiohttp.WSMsgType.CLOSE,
-                        aiohttp.WSMsgType.CLOSING,
-                        aiohttp.WSMsgType.CLOSED,
-                    ]:
-                        LOGGER.warn(
-                            f"Stopping receiving. Message type: {str(msg.type)}"
-                        )
-
-                        if (
-                            not self._auth.is_access_token_valid()
-                            or msg.data == WS_STATUS_UNAUTHORIZED
-                        ):
-                            LOGGER.debug("auth key expired, doing reauth now")
-                            await self._auth.do_auth()
-
-                        elif msg.data == WS_STATUS_GOING_AWAY:
+                    while not ws.closed:
+                        msg = await self._recv_msg(ws)
+                        if not msg:
+                            continue
+                        if msg.type == aiohttp.WSMsgType.ERROR:
+                            LOGGER.error("Socket message error")
+                            break
+                        if msg.type in [
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED,
+                        ]:
                             LOGGER.warn(
-                                f"Received Going Away message: Waiting for {GOING_AWAY_DELAY} seconds"
+                                f"Stopping receiving. Message type: {str(msg.type)}"
                             )
-                            # Give server some time to come back up.
-                            await asyncio.sleep(GOING_AWAY_DELAY)
 
-                        break
+                            if (
+                                not self._auth.is_access_token_valid()
+                                or msg.data == WS_STATUS_UNAUTHORIZED
+                            ):
+                                LOGGER.debug("auth key expired, doing reauth now")
+                                await self._auth.do_auth()
 
-                    if msg.type != aiohttp.WSMsgType.TEXT:
-                        LOGGER.error(f"Socket message type is invalid: {str(msg.type)}")
-                        continue
+                            elif msg.data == WS_STATUS_GOING_AWAY:
+                                LOGGER.warn(
+                                    f"Received Going Away message: Waiting for {GOING_AWAY_DELAY} seconds"
+                                )
+                                # Give server some time to come back up.
+                                await asyncio.sleep(GOING_AWAY_DELAY)
 
-                    match = RECV_MSG_MATCHER.findall(msg.data)
-                    if not match:
-                        continue
-                    self._msg_listener("{" + match[0] + "}")
-        except (
-            aiohttp.ClientError,
-            asyncio.TimeoutError,
-            gaierror,
-        ) as e:
-            LOGGER.error(f"Websocket could not connect: {e}")
+                            break
 
-        self._websocket = None
+                        if msg.type != aiohttp.WSMsgType.TEXT:
+                            LOGGER.error(
+                                f"Socket message type is invalid: {str(msg.type)}"
+                            )
+                            continue
 
-        if self._running:
-            self._reconnect_tries -= 1
-            if self._reconnect_tries < 0:
-                self._reconnect_tries = 0
+                        match = RECV_MSG_MATCHER.findall(msg.data)
+                        if not match:
+                            continue
+                        self._msg_listener("{" + match[0] + "}")
+            except (
+                aiohttp.ClientError,
+                asyncio.TimeoutError,
+                gaierror,
+            ) as e:
+                LOGGER.error(f"Websocket could not connect: {e}")
+
+            self._websocket = None
+
+            if self._running:
+                self._reconnect_tries -= 1
+                if self._reconnect_tries < 0:
+                    self._reconnect_tries = 0
+                    LOGGER.info(
+                        f"Waiting to reconnect long delay {RECONNECT_LONG_DELAY} seconds"
+                    )
+
+                    # Give server some time to come back up.
+                    await asyncio.sleep(RECONNECT_LONG_DELAY)
+
                 LOGGER.info(
-                    f"Waiting to reconnect long delay {RECONNECT_LONG_DELAY} seconds"
+                    f"Waiting to reconnect short delay {RECONNECT_SHORT_DELAY} seconds"
                 )
+                await asyncio.sleep(RECONNECT_SHORT_DELAY)
 
-                # Give server some time to come back up.
-                await asyncio.sleep(RECONNECT_LONG_DELAY)
-
-            LOGGER.info(
-                f"Waiting to reconnect short delay {RECONNECT_SHORT_DELAY} seconds"
-            )
-            await asyncio.sleep(RECONNECT_SHORT_DELAY)
-
-            LOGGER.info("Reconnecting...")
-            self._run_future = asyncio.get_event_loop().create_task(self._run())
+                LOGGER.info("Reconnecting...")
+                # self._run_future = asyncio.get_event_loop().create_task(self._run())
 
     def start(self):
         self._running = True
@@ -161,5 +162,5 @@ class EventSocket:
             return
         await self._websocket.close()
         self._websocket = None
-
-        await self._run_future
+        if not self._run_future.done():
+            await self._run_future

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -103,7 +103,8 @@ class EventSocket:
                                 or msg.data == WS_STATUS_UNAUTHORIZED
                             ):
                                 LOGGER.debug("auth key expired, doing reauth now")
-                                await self._auth.do_auth()
+                                while not await self._auth.do_auth():
+                                    asyncio.sleep(RECONNECT_LONG_DELAY)
 
                             elif msg.data == WS_STATUS_GOING_AWAY:
                                 LOGGER.warn(

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -98,7 +98,6 @@ class EventSocket:
                                 f"Stopping receiving. Message type: {str(msg.type)}"
                             )
 
-
                             if (
                                 not self._auth.is_access_token_valid()
                                 or msg.data == WS_STATUS_UNAUTHORIZED

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -76,10 +76,10 @@ class EventSocket:
                 heartbeat=45,
             ) as ws:
                 self._websocket = ws
+                await self._con_up_listener()
                 await self._send_msg(ws, self._create_connect_msg())
                 await self._recv_msg(ws)
                 await self._send_msg(ws, self._create_subscribe_msg())
-                await self._con_up_listener()
 
                 self._reconnect_tries = RECONNECT_COUNT
 

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -151,7 +151,6 @@ class EventSocket:
                 await asyncio.sleep(RECONNECT_SHORT_DELAY)
 
                 LOGGER.info("Reconnecting...")
-                # self._run_future = asyncio.get_event_loop().create_task(self._run())
 
     def start(self):
         self._running = True


### PR DESCRIPTION
Test for None before attempting to use dictionary functions.
Call the callback before registering for event changes (generates new key and headers)
Retry (3 times) on fetch data if auth is required. 