### PR TITLE
Add model and serial numbers

### DIFF
--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -65,6 +65,8 @@ class AppliancesManager:
                         "NAME": appliance["APPLIANCE_NAME"],
                         "DATA_MODEL": appliance["DATA_MODEL_KEY"],
                         "CATEGORY": appliance["CATEGORY_NAME"],
+                        "MODEL_NUMBER": appliance.get("MODEL_NO"),
+                        "SERIAL_NUMBER": appliance.get("SERIAL"),
                     }
                     data_model = appliance["DATA_MODEL_KEY"].lower()
                     if "airconditioner" in data_model:


### PR DESCRIPTION
Retain the appliance model number and serial number when loading location info.  I used dict.get() in case other appliances don't provide these values.

This could later be added to Home Assistant for a more complete `DeviceInfo`.

I didn't add specific tests, but existing tests pass.

