### PR TITLE
Add user-agent to auth header

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -22,7 +22,7 @@ AUTH_DATA = {
 }
 AUTH_HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded",
-    "User-Agent":"okhttp/3.12.0",
+    "User-Agent": "okhttp/3.12.0",
 }
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -22,6 +22,7 @@ AUTH_DATA = {
 }
 AUTH_HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded",
+    "User-Agent":"okhttp/3.12.0",
 }
 
 

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -82,7 +82,7 @@ class Auth:
         auth_url = self._backend_selector.auth_url
         auth_header = {
             "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent":"okhttp/3.12.0",
+            "User-Agent": "okhttp/3.12.0",
         }
 
         for client_creds in self._backend_selector.client_credentials:

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -83,7 +83,7 @@ class Auth:
         auth_header = {
             "Content-Type": "application/x-www-form-urlencoded",
             "User-Agent":"okhttp/3.12.0",
-            }
+        }
 
         for client_creds in self._backend_selector.client_credentials:
             auth_data: Dict[str, str] = self._get_auth_body(refresh_token, client_creds)

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -80,7 +80,10 @@ class Auth:
 
     async def _do_auth(self, refresh_token: str) -> Dict[str, str]:
         auth_url = self._backend_selector.auth_url
-        auth_header = {"Content-Type": "application/x-www-form-urlencoded"}
+        auth_header = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent":"okhttp/3.12.0",
+            }
 
         for client_creds in self._backend_selector.client_credentials:
             auth_data: Dict[str, str] = self._get_auth_body(refresh_token, client_creds)


### PR DESCRIPTION
Apparently whirlpool is becoming a bit more picky about the auth header - User-Agent must be "okhttp/3.12.0" or they return 403 when attempting to authenticate.

This will require are version bump so we can fix HA.

https://github.com/home-assistant/core/issues/114463
 