### PR TITLE
Move WP-CLIENT-BRAND header to get_shared_appliances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode
-scratch.py

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .vscode
+scratch.py

--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -30,8 +30,6 @@ class AppliancesManager:
             "User-Agent": "okhttp/3.12.0",
             "Pragma": "no-cache",
             "Cache-Control": "no-cache",
-            # note: WP-CLIENT-BRAND is required for `share-accounts/appliances` endpoint
-            "WP-CLIENT-BRAND": self._backend_selector.brand.name,
         }
 
     def _add_appliance(self, appliance: Dict[str, Any]) -> None:
@@ -81,9 +79,11 @@ class AppliancesManager:
             return True
 
     async def _get_shared_appliances(self) -> bool:
+        headers = self._create_headers()
+        headers["WP-CLIENT-BRAND"] = self._backend_selector.brand.name
         async with self._session.get(
             f"{self._backend_selector.base_url}/api/v1/share-accounts/appliances",
-            headers=self._create_headers(),
+            headers=headers,
         ) as r:
             if r.status != 200:
                 LOGGER.error(f"Failed to get shared appliances: {r.status}")


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/115130