### PR TITLE
Remove unused auto renewal logic

### DIFF
--- a/cli_ac_menu.py
+++ b/cli_ac_menu.py
@@ -97,7 +97,6 @@ async def show_aircon_menu(backend_selector, auth, said, session):
             await ac.send_attributes({cmd: val})
         elif choice == "q":
             await ac.disconnect()
-            auth.cancel_auto_renewal()
             print("Bye")
             loop = False
         else:

--- a/cli_oven_menu.py
+++ b/cli_oven_menu.py
@@ -132,7 +132,6 @@ async def show_oven_menu(backend_selector, auth, said, session):
             await ov.send_attributes({cmd: val})
         elif choice == "q":
             await ov.disconnect()
-            auth.cancel_auto_renewal()
             print("Bye")
             loop = False
         else:

--- a/cli_washerdryer_menu.py
+++ b/cli_washerdryer_menu.py
@@ -50,7 +50,6 @@ async def show_washerdryer_menu(backend_selector, auth, said, session):
             await wd.send_attributes({cmd: val})
         elif choice == "q":
             await wd.disconnect()
-            auth.cancel_auto_renewal()
             print("Bye")
             loop = False
         else:


### PR DESCRIPTION
Auto renewal logic has been commented out for some time, this PR removes it. It can be added back later if/when it is desired