### PR TITLE
Python-requires to >=3.11, type annotation updates, add pyupgrade to .pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,9 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.2
+    hooks:
+    - id: pyupgrade
+      args:
+        - --py311-plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.12"
 dependencies = [
     "aioconsole>=0.3.1",
     "aiohttp>=3.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "aioconsole>=0.3.1",
     "aiohttp>=3.9.1",

--- a/tests/mock_backendselector.py
+++ b/tests/mock_backendselector.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Dict, List
 
 from whirlpool.backendselector import BackendSelector
 
@@ -29,7 +28,7 @@ class BackendSelectorMock(BackendSelector):
         return "http://dummy_base_url.com"
 
     @property
-    def client_credentials(self) -> List[Dict[str, str]]:
+    def client_credentials(self) -> list[dict[str, str]]:
         return [
             {
                 "client_id": "dummy_client_id1",
@@ -40,7 +39,7 @@ class BackendSelectorMock(BackendSelector):
 
 class BackendSelectorMockMultipleCreds(BackendSelectorMock):
     @property
-    def client_credentials(self) -> List[Dict[str, str]]:
+    def client_credentials(self) -> list[dict[str, str]]:
         return [
             {
                 "client_id": "dummy_client_id1",

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 import aiohttp
 import async_timeout
@@ -31,7 +31,7 @@ class Appliance:
         self._backend_selector = backend_selector
         self._auth = auth
         self._said = said
-        self._attr_changed: list(Callable) = []
+        self._attr_changed: list[Callable] = []
         self._event_socket = None
         self._data_dict = None
 

--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 import aiohttp
 
@@ -18,21 +18,21 @@ class AppliancesManager:
     ):
         self._backend_selector = backend_selector
         self._auth = auth
-        self._aircons: List[Dict[str, Any]] = []
-        self._washer_dryers: List[Dict[str, Any]] = []
-        self._ovens: List[Dict[str, Any]] = []
+        self._aircons: list[dict[str, Any]] = []
+        self._washer_dryers: list[dict[str, Any]] = []
+        self._ovens: list[dict[str, Any]] = []
         self._session: aiohttp.ClientSession = session
 
     def _create_headers(self):
         return {
-            "Authorization": "Bearer {0}".format(self._auth.get_access_token()),
+            "Authorization": f"Bearer {self._auth.get_access_token()}",
             "Content-Type": "application/json",
             "User-Agent": "okhttp/3.12.0",
             "Pragma": "no-cache",
             "Cache-Control": "no-cache",
         }
 
-    def _add_appliance(self, appliance: Dict[str, Any]) -> None:
+    def _add_appliance(self, appliance: dict[str, Any]) -> None:
         appliance_data = {
             "SAID": appliance["SAID"],
             "NAME": appliance["APPLIANCE_NAME"],
@@ -71,7 +71,7 @@ class AppliancesManager:
                 return False
 
             data = await r.json()
-            locations: Dict[str, Any] = data[str(account_id)]
+            locations: dict[str, Any] = data[str(account_id)]
             for appliances in locations.values():
                 for appliance in appliances:
                     self._add_appliance(appliance)
@@ -90,7 +90,7 @@ class AppliancesManager:
                 return False
 
             data = await r.json()
-            locations: List[Dict[str, Any]] = data["sharedAppliances"]
+            locations: list[dict[str, Any]] = data["sharedAppliances"]
             for appliances in locations:
                 for appliance in appliances["appliances"]:
                     self._add_appliance(appliance)

--- a/whirlpool/backendselector.py
+++ b/whirlpool/backendselector.py
@@ -1,13 +1,7 @@
 import logging
 from enum import Enum
-from typing import List, TypedDict
 
 LOGGER = logging.getLogger(__name__)
-
-
-class CredentialsDict(TypedDict):
-    client_id: str
-    client_secret: str
 
 
 class Brand(Enum):
@@ -67,7 +61,7 @@ class BackendSelector:
         return BACKEND_DATA[self._region].get("base_url")
 
     @property
-    def client_credentials(self) -> List[CredentialsDict]:
+    def client_credentials(self) -> list[dict[str, str]]:
         return BACKEND_DATA[self._brand]
 
     @property

--- a/whirlpool/eventsocket.py
+++ b/whirlpool/eventsocket.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 import re
 import uuid
+from collections.abc import Callable
 from socket import gaierror
-from typing import Callable
 
 import aiohttp
 
@@ -148,11 +148,7 @@ class EventSocket:
                         if not match:
                             continue
                         self._msg_listener("{" + match[0] + "}")
-            except (
-                aiohttp.ClientError,
-                asyncio.TimeoutError,
-                gaierror,
-            ) as ex:
+            except (aiohttp.ClientError, TimeoutError, gaierror) as ex:
                 LOGGER.error(f"Websocket could not connect: {ex}")
 
             self._websocket = None

--- a/whirlpool/oven.py
+++ b/whirlpool/oven.py
@@ -147,7 +147,7 @@ class KitchenTimer:
     def __init__(self, appliance: Appliance, timer_id: int = 1):
         self._timer_id = timer_id
         self._appliance = appliance
-        self._attr_prefix = "KitchenTimer{:02d}_".format(timer_id)
+        self._attr_prefix = f"KitchenTimer{timer_id:02d}_"
 
     def get_total_time(self):
         return self._appliance.get_attribute(


### PR DESCRIPTION
Closes #57 

- Sets python-requires to >=3.11
- Adds pyupgrade to .pre-commit-config.yaml with --py311-plus argument
- Switches out `Dict` and `List` to builtins
- Corrects type annotation in `Appliance`
- Removes unnecessary `CredentialsDict` `TypedDict` in `backendselector.py`

No type annotations were added, just modified/corrected existing ones