### PR TITLE
Feature/move urls to backend selector

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,38 +21,12 @@ def http_client_mock(mocker, backend_selector_mock):
 
 
 @pytest.fixture
-def appliance_http_client_mock(http_client_mock, backend_selector_mock):
+def appliance_http_client_mock(
+    http_client_mock, backend_selector_mock: BackendSelectorMock
+):
     http_client_mock.get(
-        f"{backend_selector_mock.base_url}/api/v1/client_auth/webSocketUrl",
-        json={"url": "wss://something"},
+        backend_selector_mock.websocket_url, json={"url": "wss://something"}
     )
-
-    # async def ws_get_side_effect(method, url, data, headers):
-    #     ws_key: str = headers[hdrs.SEC_WEBSOCKET_KEY]
-    #     accept_key = base64.b64encode(
-    #         hashlib.sha1(ws_key.encode("utf-8") + http_websocket.WS_KEY).digest()
-    #     ).decode()
-    #     return AiohttpClientMockResponse(
-    #         method=method,
-    #         url=url,
-    #         status=HTTPStatus.SWITCHING_PROTOCOLS,
-    #         headers={
-    #             hdrs.UPGRADE: "websocket",
-    #             hdrs.CONNECTION: "upgrade",
-    #             hdrs.SEC_WEBSOCKET_ACCEPT: accept_key,
-    #         },
-    #     )
-    # appliance_httpclient.get(
-    #     "wss://something",
-    #     json={},
-    #     status=HTTPStatus.SWITCHING_PROTOCOLS,
-    #     headers={
-    #         hdrs.UPGRADE: "websocket",
-    #         hdrs.CONNECTION: "upgrade",
-    #         hdrs.SEC_WEBSOCKET_ACCEPT: "s3pPLMBiTxaQ9kYGzzhZRbK",
-    #     },
-    #     side_effect=ws_get_side_effect,
-    # )
 
     return http_client_mock
 

--- a/tests/test_appliancesmanager.py
+++ b/tests/test_appliancesmanager.py
@@ -29,7 +29,7 @@ def assert_appliances_manager_call(
 
     call = mock_calls[call_index]
     assert call[0] == "GET"
-    assert path.endswith(call[1].path)
+    assert BACKEND_SELECTOR_MOCK.base_url + call[1].path == path
     # call[2] is body, which will be None
 
     if required_headers is not None:

--- a/tests/test_appliancesmanager.py
+++ b/tests/test_appliancesmanager.py
@@ -23,17 +23,22 @@ def assert_appliances_manager_call(
     call_index: int,
     path: str,
     required_headers: dict = None,
+    forbidden_headers: list = None,
 ):
     mock_calls = http_client_mock.mock_calls
 
     call = mock_calls[call_index]
     assert call[0] == "GET"
-    assert call[1].path == path
+    assert path.endswith(call[1].path)
     # call[2] is body, which will be None
 
     if required_headers is not None:
         for k, v in required_headers.items():
             assert call[3][k] == v
+
+    if forbidden_headers is not None:
+        for k in forbidden_headers:
+            assert k not in call[3]
 
 
 @pytest.mark.parametrize("account_id", [None, ACCOUNT_ID])
@@ -62,20 +67,23 @@ async def test_fetch_appliances_with_set_account_id(
 
     if account_id is None:
         # make sure that the first call in this case is to get the account id
-        assert_appliances_manager_call(http_client_mock, 0, "/api/v1/getUserDetails")
+        assert_appliances_manager_call(
+            http_client_mock, 0, BACKEND_SELECTOR_MOCK.user_details_url
+        )
 
     # this should always be called
     assert_appliances_manager_call(
         http_client_mock,
         get_appliances_idx,
-        f"/api/v2/appliance/all/account/{ACCOUNT_ID}",
+        BACKEND_SELECTOR_MOCK.get_owned_appliances_url(ACCOUNT_ID),
+        forbidden_headers=["WP-CLIENT-BRAND"],
     )
 
     # this should always be called and requires the WP-CLIENT-BRAND header
     assert_appliances_manager_call(
         http_client_mock,
         get_appliances_idx + 1,
-        "/api/v1/share-accounts/appliances",
+        BACKEND_SELECTOR_MOCK.shared_appliances_url,
         {"WP-CLIENT-BRAND": "DUMMY_BRAND"},
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,8 +40,7 @@ def mock_appliance_http_get(
     data,
 ):
     appliance_http_client_mock.get(
-        f"{backend_selector_mock.base_url}/api/v1/appliance/{said}",
-        json=data,
+        backend_selector_mock.get_appliance_data_url(said), json=data
     )
 
 
@@ -49,9 +48,7 @@ def mock_appliance_http_post(
     appliance_http_client_mock: AiohttpClientMocker,
     backend_selector_mock: BackendSelectorMock,
 ):
-    appliance_http_client_mock.post(
-        f"{backend_selector_mock.base_url}/api/v1/appliance/command"
-    )
+    appliance_http_client_mock.post(backend_selector_mock.appliance_command_url)
 
 
 def mock_appliancesmanager_get_account_id_get(
@@ -59,7 +56,7 @@ def mock_appliancesmanager_get_account_id_get(
     backend_selector_mock: BackendSelectorMock,
 ):
     http_client_mock.get(
-        f"{backend_selector_mock.base_url}/api/v1/getUserDetails",
+        backend_selector_mock.user_details_url,
         content=json.dumps({"accountId": "12345"}).encode("utf-8"),
     )
 
@@ -75,8 +72,7 @@ def mock_appliancesmanager_get_owned_appliances_get(
     content = json.dumps({account_id: owned_appliance_data}).encode("utf-8")
 
     http_client_mock.get(
-        f"{backend_selector_mock.base_url}/api/v2/appliance/all/account/{account_id}",
-        content=content,
+        backend_selector_mock.get_owned_appliances_url(account_id), content=content
     )
 
 
@@ -89,7 +85,4 @@ def mock_appliancesmanager_get_shared_appliances_get(
 
     content = json.dumps(shared_appliance_data).encode("utf-8")
 
-    http_client_mock.get(
-        f"{backend_selector_mock.base_url}/api/v1/share-accounts/appliances",
-        content=content,
-    )
+    http_client_mock.get(backend_selector_mock.shared_appliances_url, content=content)

--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -63,7 +63,7 @@ class AppliancesManager:
 
     async def _get_owned_appliances(self, account_id: str) -> bool:
         async with self._session.get(
-            f"{self._backend_selector.base_url}/api/v2/appliance/all/account/{account_id}",
+            self._backend_selector.get_owned_appliances_url(account_id),
             headers=self._create_headers(),
         ) as r:
             if r.status != 200:
@@ -82,8 +82,7 @@ class AppliancesManager:
         headers = self._create_headers()
         headers["WP-CLIENT-BRAND"] = self._backend_selector.brand.name
         async with self._session.get(
-            f"{self._backend_selector.base_url}/api/v1/share-accounts/appliances",
-            headers=headers,
+            self._backend_selector.shared_appliances_url, headers=headers
         ) as r:
             if r.status != 200:
                 LOGGER.error(f"Failed to get shared appliances: {r.status}")
@@ -103,7 +102,7 @@ class AppliancesManager:
             return self._auth.get_account_id()
 
         async with self._session.get(
-            f"{self._backend_selector.base_url}/api/v1/getUserDetails",
+            self._backend_selector.user_details_url,
             headers=self._create_headers(),
         ) as r:
             if r.status != 200:

--- a/whirlpool/auth.py
+++ b/whirlpool/auth.py
@@ -54,7 +54,7 @@ class Auth:
         return auth_data
 
     async def _do_auth(self, refresh_token: str) -> dict[str, str]:
-        auth_url = self._backend_selector.auth_url
+        auth_url = self._backend_selector.oauth_token_url
         auth_header = {
             "Content-Type": "application/x-www-form-urlencoded",
             "User-Agent": "okhttp/3.12.0",

--- a/whirlpool/backendselector.py
+++ b/whirlpool/backendselector.py
@@ -1,21 +1,10 @@
 import logging
-from enum import Enum
+
+from .types import Brand, Region
 
 LOGGER = logging.getLogger(__name__)
 
-
-class Brand(Enum):
-    Whirlpool = 0
-    Maytag = 1
-    KitchenAid = 2
-
-
-class Region(Enum):
-    EU = 0
-    US = 1
-
-
-BACKEND_DATA = {
+CREDENTIALS: dict[Brand, list[dict[str, str]]] = {
     Brand.Whirlpool: [
         {
             "client_id": "whirlpool_android",
@@ -38,9 +27,14 @@ BACKEND_DATA = {
             "client_secret": "kkdPquOHfNH-iIinccTdhAkJmaIdWBhLehhLrfoXRWbKjEpqpdu92PISF_yJEWQs72D2yeC0PdoEKeWgHR9JRA",
         }
     ],
-    Region.EU: {"base_url": "https://prod-api.whrcloud.eu"},
-    Region.US: {"base_url": "https://api.whrcloud.com"},
 }
+
+URLS: dict[Region, str] = {
+    Region.EU: "https://prod-api.whrcloud.eu",
+    Region.US: "https://api.whrcloud.com",
+}
+
+BACKEND_DATA = CREDENTIALS | URLS
 
 
 class BackendSelector:
@@ -58,12 +52,34 @@ class BackendSelector:
 
     @property
     def base_url(self):
-        return BACKEND_DATA[self._region].get("base_url")
+        return URLS[self._region]
 
     @property
     def client_credentials(self) -> list[dict[str, str]]:
-        return BACKEND_DATA[self._brand]
+        return CREDENTIALS[self._brand]
 
     @property
-    def auth_url(self):
+    def appliance_command_url(self):
+        return f"{self.base_url}/api/v1/appliance/command"
+
+    @property
+    def oauth_token_url(self):
         return f"{self.base_url}/oauth/token"
+
+    @property
+    def websocket_url(self):
+        return f"{self.base_url}/api/v1/client_auth/webSocketUrl"
+
+    @property
+    def user_details_url(self):
+        return f"{self.base_url}/api/v1/getUserDetails"
+
+    @property
+    def shared_appliances_url(self):
+        return f"{self.base_url}/api/v1/share-accounts/appliances"
+
+    def get_appliance_data_url(self, said: str):
+        return f"{self.base_url}/api/v1/appliance/{said}"
+
+    def get_owned_appliances_url(self, account_id: str):
+        return f"{self.base_url}/api/v2/appliance/all/account/{account_id}"

--- a/whirlpool/backendselector.py
+++ b/whirlpool/backendselector.py
@@ -43,15 +43,15 @@ class BackendSelector:
         self._region = region
 
     @property
-    def brand(self):
+    def brand(self) -> Brand:
         return self._brand
 
     @property
-    def region(self):
+    def region(self) -> Region:
         return self._region
 
     @property
-    def base_url(self):
+    def base_url(self) -> str:
         return URLS[self._region]
 
     @property
@@ -59,27 +59,27 @@ class BackendSelector:
         return CREDENTIALS[self._brand]
 
     @property
-    def appliance_command_url(self):
+    def appliance_command_url(self) -> str:
         return f"{self.base_url}/api/v1/appliance/command"
 
     @property
-    def oauth_token_url(self):
+    def oauth_token_url(self) -> str:
         return f"{self.base_url}/oauth/token"
 
     @property
-    def websocket_url(self):
+    def websocket_url(self) -> str:
         return f"{self.base_url}/api/v1/client_auth/webSocketUrl"
 
     @property
-    def user_details_url(self):
+    def user_details_url(self) -> str:
         return f"{self.base_url}/api/v1/getUserDetails"
 
     @property
-    def shared_appliances_url(self):
+    def shared_appliances_url(self) -> str:
         return f"{self.base_url}/api/v1/share-accounts/appliances"
 
-    def get_appliance_data_url(self, said: str):
+    def get_appliance_data_url(self, said: str) -> str:
         return f"{self.base_url}/api/v1/appliance/{said}"
 
-    def get_owned_appliances_url(self, account_id: str):
+    def get_owned_appliances_url(self, account_id: str) -> str:
         return f"{self.base_url}/api/v2/appliance/all/account/{account_id}"

--- a/whirlpool/types.py
+++ b/whirlpool/types.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Brand(Enum):
+    Whirlpool = 0
+    Maytag = 1
+    KitchenAid = 2
+
+
+class Region(Enum):
+    EU = 0
+    US = 1
+
+
+@dataclass
+class ApplianceData:
+    said: str
+    name: str
+    data_model: str
+    category: str
+    model_number: str
+    serial_number: str

--- a/whirlpool/types.py
+++ b/whirlpool/types.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from enum import Enum
 
 
@@ -11,13 +10,3 @@ class Brand(Enum):
 class Region(Enum):
     EU = 0
     US = 1
-
-
-@dataclass
-class ApplianceData:
-    said: str
-    name: str
-    data_model: str
-    category: str
-    model_number: str
-    serial_number: str


### PR DESCRIPTION
- create a `types.py` module for enums
  - another branch of mine where i started work on the event socket had additional types in this file, so it felt worthwhile to go ahead and make it since it will have more stuff added to it soon
  - but if we feel like it's premature or just don't want it i'm happy to move these back to backendselector
- add url properties and url methods to backend selector
- update all use of urls to use backend_selector
- add type hints to backend selector
- remove some commented out code in conftest.py
- add a check in `test_appliancesmanager` that `WP-CLIENT-BRAND` is not in the "owned appliances" call