### PR TITLE
Reduce log level for shared appliances fetch fail

### DIFF
--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -97,7 +97,7 @@ class AppliancesManager:
             self._backend_selector.shared_appliances_url, headers=headers
         ) as r:
             if r.status != 200:
-                LOGGER.error(f"Failed to get shared appliances: {r.status}")
+                LOGGER.warning(f"Failed to get shared appliances: {r.status}")
                 return False
 
             data = await r.json()


### PR DESCRIPTION
It seems that this endpoint is not available for all brand/region
combos.
