### PR TITLE
Bump to v0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whirlpool_sixth_sense"
-version = "0.18.12"
+version = "0.19"
 authors = [{ name = "Abílio Costa", email = "amfcalt@gmail.com" }]
 description = "Unofficial API for Whirlpool's 6th Sense appliances"
 classifiers = [


### PR DESCRIPTION
This is a breaking release. Previously appliance instances would have to
be created directly and each one would use its own websocket to receive
updates.
With this release, the AppliancesManager is responsible for creating
appliance instances and those should be fetched from there.
