### PR TITLE
Prefix get_attribute with underscore (breaking change)

### DIFF
--- a/whirlpool/aircon.py
+++ b/whirlpool/aircon.py
@@ -80,20 +80,20 @@ FANSPEED_MAP = {
 
 class Aircon(Appliance):
     def get_current_temp(self) -> float | None:
-        raw_temp = self.get_int_attribute(ATTR_DISPLAY_TEMP)
+        raw_temp = self._get_int_attribute(ATTR_DISPLAY_TEMP)
         return raw_temp / 10 if raw_temp is not None else None
 
     def get_current_humidity(self) -> int | None:
-        return self.get_int_attribute(ATTR_DISPLAY_HUMID)
+        return self._get_int_attribute(ATTR_DISPLAY_HUMID)
 
     def get_power_on(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_POWER))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_POWER))
 
     async def set_power_on(self, on: bool):
         await self.send_attributes({SETTING_POWER: self.bool_to_attr_value(on)})
 
     def get_temp(self) -> float | None:
-        raw_temp = self.get_int_attribute(SETTING_TEMP)
+        raw_temp = self._get_int_attribute(SETTING_TEMP)
         return raw_temp / 10 if raw_temp is not None else None
 
     async def set_temp(self, temp: float):
@@ -101,13 +101,13 @@ class Aircon(Appliance):
         await self.send_attributes({SETTING_TEMP: str(tempint)})
 
     def get_humidity(self) -> int | None:
-        return self.get_int_attribute(SETTING_HUMIDITY)
+        return self._get_int_attribute(SETTING_HUMIDITY)
 
     async def set_humidity(self, temp: int):
         await self.send_attributes({SETTING_HUMIDITY: str(temp)})
 
     def get_mode(self) -> Mode | None:
-        mode_raw = self.get_attribute(ATTR_MODE)
+        mode_raw = self._get_attribute(ATTR_MODE)
         if mode_raw in [ATTRVAL_MODE_COOL, ATTRVAL_MODE_SIXTH_SENSE_COOL]:
             return Mode.Cool
         if mode_raw in [ATTRVAL_MODE_HEAT, ATTRVAL_MODE_SIXTH_SENSE_HEAT]:
@@ -117,7 +117,7 @@ class Aircon(Appliance):
         return None
 
     def get_sixthsense_mode(self) -> bool:
-        return self.get_attribute(SETTING_MODE) == SETVAL_MODE_SIXTH_SENSE
+        return self._get_attribute(SETTING_MODE) == SETVAL_MODE_SIXTH_SENSE
 
     async def set_mode(self, mode: Mode):
         if mode not in MODES_MAP:
@@ -125,7 +125,7 @@ class Aircon(Appliance):
         await self.send_attributes({SETTING_MODE: MODES_MAP[mode]})
 
     def get_fanspeed(self) -> FanSpeed | None:
-        fanspeed_raw = self.get_attribute(SETTING_FAN_SPEED)
+        fanspeed_raw = self._get_attribute(SETTING_FAN_SPEED)
         for k, v in FANSPEED_MAP.items():
             if v == fanspeed_raw:
                 return k
@@ -137,7 +137,7 @@ class Aircon(Appliance):
         await self.send_attributes({SETTING_FAN_SPEED: FANSPEED_MAP[speed]})
 
     def get_h_louver_swing(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_HORZ_LOUVER_SWING))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_HORZ_LOUVER_SWING))
 
     async def set_h_louver_swing(self, swing: bool):
         await self.send_attributes(
@@ -145,26 +145,26 @@ class Aircon(Appliance):
         )
 
     def get_turbo_mode(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_TURBO_MODE))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_TURBO_MODE))
 
     async def set_turbo_mode(self, turbo: bool):
         await self.send_attributes({SETTING_TURBO_MODE: self.bool_to_attr_value(turbo)})
 
     def get_eco_mode(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_ECO_MODE))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_ECO_MODE))
 
     async def set_eco_mode(self, eco: bool):
         await self.send_attributes({SETTING_ECO_MODE: self.bool_to_attr_value(eco)})
 
     def get_quiet_mode(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_QUIET_MODE))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_QUIET_MODE))
 
     async def set_quiet_mode(self, quiet: bool):
         await self.send_attributes({SETTING_QUIET_MODE: self.bool_to_attr_value(quiet)})
 
     def get_display_on(self) -> bool | None:
         return (
-            self.get_attribute(SETTING_DISPLAY_BRIGHTNESS)
+            self._get_attribute(SETTING_DISPLAY_BRIGHTNESS)
             == SETVAL_DISPLAY_BRIGHTNESS_ON
         )
 

--- a/whirlpool/appliance.py
+++ b/whirlpool/appliance.py
@@ -130,15 +130,15 @@ class Appliance:
         self._data_dict["attributes"][attribute]["value"] = value
         self._data_dict["attributes"][attribute]["updateTime"] = timestamp
 
-    def get_attribute(self, attribute: str) -> str | None:
+    def _get_attribute(self, attribute: str) -> str | None:
         """Get attribute from local data dictionary"""
         if not self.has_attribute(attribute):
             return None
         return self._data_dict["attributes"][attribute]["value"]
 
-    def get_int_attribute(self, attribute: str) -> int | None:
+    def _get_int_attribute(self, attribute: str) -> int | None:
         """Get attribute from local data as int"""
-        val = self.get_attribute(attribute)
+        val = self._get_attribute(attribute)
         return None if val is None else int(val)
 
     def has_attribute(self, attribute: str) -> bool:
@@ -158,4 +158,4 @@ class Appliance:
 
     def get_online(self) -> bool | None:
         """Get online state for appliance"""
-        return self.attr_value_to_bool(self.get_attribute(ATTR_ONLINE))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_ONLINE))

--- a/whirlpool/oven.py
+++ b/whirlpool/oven.py
@@ -148,17 +148,17 @@ class KitchenTimer:
         self._attr_prefix = f"KitchenTimer{timer_id:02d}_"
 
     def get_total_time(self):
-        return self._appliance.get_attribute(
+        return self._appliance._get_attribute(
             self._attr_prefix + ATTR_POSTFIX_KITCHEN_TIMER_SET_TIME
         )
 
     def get_remaining_time(self):
-        return self._appliance.get_attribute(
+        return self._appliance._get_attribute(
             self._attr_prefix + ATTR_POSTFIX_KITCHEN_TIMER_TIME_REMAINING
         )
 
     def get_state(self):
-        state_raw = self._appliance.get_attribute(
+        state_raw = self._appliance._get_attribute(
             self._attr_prefix + ATTR_POSTFIX_KITCHEN_TIMER_STATUS
         )
         for k, v in KITCHEN_TIMER_STATE_MAP.items():
@@ -198,40 +198,40 @@ class KitchenTimer:
 class Oven(Appliance):
     def get_meat_probe_status(self, cavity: Cavity = Cavity.Upper):
         return self.attr_value_to_bool(
-            self.get_attribute(
+            self._get_attribute(
                 CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_MEAT_PROBE_STATUS
             )
         )
 
     def get_door_opened(self, cavity: Cavity = Cavity.Upper):
         return self.attr_value_to_bool(
-            self.get_attribute(
+            self._get_attribute(
                 CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_DOOR_OPEN_STATUS
             )
         )
 
     def get_display_brightness_percent(self) -> int | None:
-        brightness = self.get_attribute(ATTR_DISPLAY_BRIGHTNESS)
+        brightness = self._get_attribute(ATTR_DISPLAY_BRIGHTNESS)
         return int(brightness) if brightness is not None else None
 
     async def set_display_brightness_percent(self, pct: int):
         await self.send_attributes({ATTR_DISPLAY_BRIGHTNESS: str(pct)})
 
     def get_cook_time(self, cavity: Cavity = Cavity.Upper):
-        time = self.get_attribute(
+        time = self._get_attribute(
             CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_COOK_TIME
         )
         return int(time) if time is not None else None
 
     def get_control_locked(self):
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CONTROL_LOCK))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CONTROL_LOCK))
 
     async def set_control_locked(self, on: bool):
         await self.send_attributes({ATTR_CONTROL_LOCK: self.bool_to_attr_value(on)})
 
     def get_light(self, cavity: Cavity = Cavity.Upper):
         return self.attr_value_to_bool(
-            self.get_attribute(
+            self._get_attribute(
                 CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_LIGHT_STATUS
             )
         )
@@ -246,7 +246,7 @@ class Oven(Appliance):
         )
 
     def get_temp(self, cavity: Cavity = Cavity.Upper):
-        reported_temp = self.get_attribute(
+        reported_temp = self._get_attribute(
             CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_TEMP
         )
         # temperatures are returned in 1/10ths of a degree Celsius,
@@ -254,7 +254,7 @@ class Oven(Appliance):
         return None if reported_temp is None else int(reported_temp) / 10
 
     def get_target_temp(self, cavity: Cavity = Cavity.Upper):
-        reported_temp = self.get_attribute(
+        reported_temp = self._get_attribute(
             CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_TARGET_TEMP
         )
         # temperatures are returned in 1/10ths of a degree Celsius,
@@ -262,7 +262,7 @@ class Oven(Appliance):
         return None if reported_temp is None else int(reported_temp) / 10
 
     def get_cavity_state(self, cavity: Cavity = Cavity.Upper):
-        state_raw = self.get_attribute(
+        state_raw = self._get_attribute(
             CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_STATUS_STATE
         )
         for k, v in CAVITY_STATE_MAP.items():
@@ -281,7 +281,7 @@ class Oven(Appliance):
         return timer
 
     def get_cook_mode(self, cavity: Cavity = Cavity.Upper):
-        cook_mode_raw = self.get_attribute(
+        cook_mode_raw = self._get_attribute(
             CAVITY_PREFIX_MAP[cavity] + "_" + ATTR_POSTFIX_COOK_MODE
         )
         for k, v in COOK_MODE_MAP.items():
@@ -325,7 +325,7 @@ class Oven(Appliance):
         )
 
     def get_sabbath_mode(self):
-        return self.attr_value_to_bool(self.get_attribute(ATTR_SABBATH_MODE))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_SABBATH_MODE))
 
     async def set_sabbath_mode(self, on: bool):
         await self.send_attributes({ATTR_SABBATH_MODE: self.bool_to_attr_value(on)})

--- a/whirlpool/refrigerator.py
+++ b/whirlpool/refrigerator.py
@@ -20,7 +20,7 @@ TEMP_MAP = {
 class Refrigerator(Appliance):
     def get_offset_temp(self) -> int | None:
         reversed_temp_map = {v: k for k, v in TEMP_MAP.items()}
-        raw_temp = self.get_int_attribute(SETTING_TEMP)
+        raw_temp = self._get_int_attribute(SETTING_TEMP)
         return reversed_temp_map[raw_temp] if raw_temp is not None else None
 
     async def set_offset_temp(self, temp):
@@ -32,7 +32,7 @@ class Refrigerator(Appliance):
             )
 
     def get_temp(self) -> int | None:
-        return self.get_int_attribute(SETTING_TEMP)
+        return self._get_int_attribute(SETTING_TEMP)
 
     async def set_temp(self, temp: int):
         if temp in TEMP_MAP.values():
@@ -43,13 +43,13 @@ class Refrigerator(Appliance):
             )
 
     def get_turbo_mode(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_TURBO_MODE))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_TURBO_MODE))
 
     async def set_turbo_mode(self, turbo: bool):
         await self.send_attributes({SETTING_TURBO_MODE: self.bool_to_attr_value(turbo)})
 
     def get_display_lock(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(SETTING_DISPLAY_LOCK))
+        return self.attr_value_to_bool(self._get_attribute(SETTING_DISPLAY_LOCK))
 
     async def set_display_lock(self, display: bool):
         await self.send_attributes(

--- a/whirlpool/washerdryer.py
+++ b/whirlpool/washerdryer.py
@@ -84,35 +84,35 @@ MACHINE_STATE_MAP = {
 
 class WasherDryer(Appliance):
     def get_machine_state(self) -> MachineState | None:
-        state_raw = self.get_attribute(ATTR_MACHINE_STATE)
+        state_raw = self._get_attribute(ATTR_MACHINE_STATE)
         for k, v in MACHINE_STATE_MAP.items():
             if v == state_raw:
                 return k
         return None
 
     def get_cycle_status_sensing(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_SENSING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_SENSING))
 
     def get_cycle_status_filling(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_FILLING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_FILLING))
 
     def get_cycle_status_soaking(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_SOAKING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_SOAKING))
 
     def get_cycle_status_washing(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_WASHING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_WASHING))
 
     def get_cycle_status_rinsing(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_RINSING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_RINSING))
 
     def get_cycle_status_spinning(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_CYCLE_STATUS_SPINNING))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_CYCLE_STATUS_SPINNING))
 
     def get_dispense_1_level(self) -> int | None:
-        return self.get_int_attribute(ATTR_DISPENSE_1_LEVEL)
+        return self._get_int_attribute(ATTR_DISPENSE_1_LEVEL)
 
     def get_door_open(self) -> bool | None:
-        return self.attr_value_to_bool(self.get_attribute(ATTR_DOOR_OPEN))
+        return self.attr_value_to_bool(self._get_attribute(ATTR_DOOR_OPEN))
 
     def get_time_remaining(self) -> int | None:
-        return self.get_int_attribute(ATTR_TIME_REMAINING)
+        return self._get_int_attribute(ATTR_TIME_REMAINING)


### PR DESCRIPTION
This should not be used directly, since attributes should be accessed by
methods in the derived appliance classes.
