### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "whirlpool_sixth_sense"
 version = "0.20.0"
+license = "MIT"
 authors = [{ name = "Abílio Costa", email = "amfcalt@gmail.com" }]
 description = "Unofficial API for Whirlpool's 6th Sense appliances"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
Setuptools `v77` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.

Metadata diff
```diff
 ...
+License-Expression: MIT
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
```