### PR TITLE
feat: add tourmaline_v2 for W9 MWO and Ovens

### DIFF
--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -86,6 +86,8 @@ class AppliancesManager:
             "ddm_cooking_bio_self_clean_tourmaline_v2",
             "ddm_cooking_bio_g3evo_pyro_bk_v1",
             "ddm_cooking_bio_self_clean_meat_probe_tourmaline_bk_v1",
+            "ddm_cooking_bio_self_clean_steam_tourmaline_v2",      # <-- W9 Ovens
+            "ddm_cooking_bi_mwo_self_clean_steam_tourmaline_v2",   # <-- W9 MWOs
         ]
 
         LOGGER.debug("Adding appliance %s", appliance_data)


### PR DESCRIPTION
## Description
Adds support for Whirlpool W9 series built-in ovens and microwaves with steam functionality.

## Data models added
- `ddm_cooking_bio_self_clean_steam_tourmaline_v2` - Built-in oven (W9 series)
- `ddm_cooking_bi_mwo_self_clean_steam_tourmaline_v2` - Built-in microwave/oven combo (W9 series)

## Testing
Tested with:
- **Oven**: Whirlpool W9 (Model: 859991551170)
- **Microwave**: Whirlpool W9 (Model: 859991542270)

Both appliances are correctly recognized and the `Oven` class works perfectly - all getters return valid data (temperature, door status, cook mode, etc.)

The only issue was that `AppliancesManager` filtered them out due to unrecognized data model names.

## Verification script
```python
from whirlpool.oven import Oven
from whirlpool.types import ApplianceInfo

forno_info = ApplianceInfo(
    said="WPR4XBX9TT9CC",
    name="Forno W9",
    data_model="ddm_cooking_bio_self_clean_steam_tourmaline_v2",
    category="cooking",
    model_number="859991551170",
    serial_number="xxx"
)

oven = Oven(backend, auth, session, forno_info)
await oven.fetch_data()

print(oven.get_online())        # True
print(oven.get_door_opened())   # False
print(oven.get_cavity_state())  # CavityState.Standby
print(oven.get_light())         # False
```