### PR TITLE
AWS IoT (2/4): Presence / online state

### DIFF
--- a/tests/test_microwave.py
+++ b/tests/test_microwave.py
@@ -340,3 +340,73 @@ async def test_cook_timer_time_complete_returns_timestamp(
         },
     )
     assert mwo.get_cook_timer_time_complete() == 1_776_101_159
+
+
+async def test_get_online_is_none_before_any_presence_event(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, _ = aws_manager
+    mwo = manager.microwaves[0]
+    assert mwo.get_online() is None
+
+
+async def test_presence_connected_sets_online_true(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+
+    fake_mqtt.inject(
+        f"$aws/events/presence/connected/{MWO_SAID}",
+        {"eventType": "connected", "clientId": "device", "timestamp": 1},
+    )
+    assert mwo.get_online() is True
+
+
+async def test_presence_disconnected_sets_online_false(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+
+    fake_mqtt.inject(
+        f"$aws/events/presence/connected/{MWO_SAID}",
+        {"eventType": "connected", "clientId": "device", "timestamp": 1},
+    )
+    fake_mqtt.inject(
+        f"$aws/events/presence/disconnected/{MWO_SAID}",
+        {"eventType": "disconnected", "clientId": "device", "timestamp": 2},
+    )
+    assert mwo.get_online() is False
+
+
+async def test_presence_event_fires_attr_callback(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+    calls: list[bool | None] = []
+    mwo.register_attr_callback(lambda: calls.append(mwo.get_online()))
+
+    fake_mqtt.inject(
+        f"$aws/events/presence/connected/{MWO_SAID}",
+        {"eventType": "connected", "clientId": "device", "timestamp": 1},
+    )
+    fake_mqtt.inject(
+        f"$aws/events/presence/disconnected/{MWO_SAID}",
+        {"eventType": "disconnected", "clientId": "device", "timestamp": 2},
+    )
+    assert calls == [True, False]
+
+
+async def test_presence_for_unknown_said_is_ignored(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+
+    fake_mqtt.inject(
+        "$aws/events/presence/connected/UNKNOWN_SAID",
+        {"eventType": "connected", "clientId": "device", "timestamp": 1},
+    )
+    assert mwo.get_online() is None

--- a/whirlpool/awsiot/appliance.py
+++ b/whirlpool/awsiot/appliance.py
@@ -24,6 +24,7 @@ class Appliance(BaseAppliance):
 
         self._data_dict: dict[str, Any] = {}
         self._initial_data_event = asyncio.Event()
+        self._online: bool | None = None
 
     def __repr__(self):
         return f"<{self.__class__.__name__}> {self.said} | {self.name}"
@@ -63,6 +64,12 @@ class Appliance(BaseAppliance):
         for callback in self._attr_changed:
             callback()
 
+    def update_online(self, online: bool):
+        """Update presence state and call callbacks."""
+        self._online = online
+        for callback in self._attr_changed:
+            callback()
+
     @override
     async def fetch_data(self) -> bool:
         """Fetch appliance data."""
@@ -76,8 +83,11 @@ class Appliance(BaseAppliance):
 
     @override
     def get_online(self) -> bool | None:
-        """Get online state for appliance"""
-        raise NotImplementedError
+        """Get online state for appliance.
+
+        Returns None until the first AWS IoT presence event is received.
+        """
+        return self._online
 
     @override
     def get_raw_data(self) -> dict[str, Any] | None:

--- a/whirlpool/awsiot/appliancesmanager.py
+++ b/whirlpool/awsiot/appliancesmanager.py
@@ -155,6 +155,19 @@ class AppliancesManager:
 
     def _handle_mqtt_message(self, topic: str, payload: dict[str, Any]) -> None:
         LOGGER.debug("Received MQTT message on topic %s: %s", topic, payload)
+
+        if topic.startswith("$aws/events/presence/"):
+            parts = topic.split("/")
+            # $aws/events/presence/{connected|disconnected}/{said}
+            if len(parts) != 5:
+                return
+            event, said = parts[3], parts[4]
+            appliance = self.all_appliances.get(said)
+            if appliance is None:
+                return
+            appliance.update_online(event == "connected")
+            return
+
         parts = topic.split("/")
         if len(parts) < 3:
             return


### PR DESCRIPTION
## Summary

Wires up the receive side for `$aws/events/presence/{connected,disconnected}/{said}` MQTT topics. The subscriptions were already in `awsiot.Appliance.subscribe_topics()`; this PR routes the events through `_handle_mqtt_message` to a new `Appliance.update_online(bool)` method and has `get_online()` return the cached state instead of raising `NotImplementedError`.

Online state is `None` until the first presence event arrives.

## Stacking

Rebased onto `aws_iot` after #126 merged. This PR now contains only the presence / online-state changes.

## Test plan

- [x] `python -m pytest tests/test_microwave.py` - 14 passed, including 5 presence tests using the existing fake-MQTT fixture:
  - `get_online()` is `None` before any presence event
  - `connected` topic -> `True`
  - `disconnected` topic -> `False`
  - attr-callback fires on each transition
  - presence event for an unknown SAID is ignored
- [x] `python -m ruff check tests/test_microwave.py whirlpool/awsiot/appliance.py whirlpool/awsiot/appliancesmanager.py`
- [x] `basedpyright` clean on changed files

## Notes

Per @abmantis's review on #124: tests assert behavior at the wire boundary (MQTT topic + payload) rather than poking `_state` directly.
