### PR TITLE
AWS IoT: auto-reconnect MQTT client after unexpected disconnect

### DIFF
--- a/tests/awsiot/test_auth.py
+++ b/tests/awsiot/test_auth.py
@@ -1,0 +1,96 @@
+"""Tests for AWS Cognito credential refresh on expiration."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from whirlpool.awsiot.auth import Auth
+
+
+@pytest.fixture
+def mock_whirlpool_auth() -> MagicMock:
+    auth = MagicMock()
+    auth.is_access_token_valid.return_value = True
+    auth.get_access_token.return_value = "fake-access-token"
+    auth.do_auth = AsyncMock(return_value=True)
+    return auth
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    return MagicMock(spec=["get", "post"])
+
+
+class TestCredentialExpiration:
+    async def test_expired_credentials_are_refreshed(
+        self, mock_whirlpool_auth: MagicMock, mock_session: MagicMock
+    ) -> None:
+        """When cached AWS credentials have expired, get_aws_credentials
+        must clear the cache and fetch fresh ones — otherwise SigV4 URLs
+        are signed with expired keys and the broker rejects the handshake."""
+
+        auth = Auth(mock_whirlpool_auth, mock_session)
+
+        expired_creds = {
+            "AccessKeyId": "OLD_KEY",
+            "SecretKey": "OLD_SECRET",
+            "SessionToken": "OLD_TOKEN",
+            "Expiration": time.time() - 600,
+        }
+        fresh_creds = {
+            "AccessKeyId": "NEW_KEY",
+            "SecretKey": "NEW_SECRET",
+            "SessionToken": "NEW_TOKEN",
+            "Expiration": time.time() + 3600,
+        }
+
+        # Pre-populate the cache with expired credentials.
+        auth._aws_credentials = expired_creds
+        auth._cognito_identity_id = "old-id"
+        auth._cognito_token = "old-token"
+
+        # Mock the HTTP calls that happen on re-fetch.
+        cognito_response = AsyncMock()
+        cognito_response.status = 200
+        cognito_response.json = AsyncMock(
+            return_value={"identityId": "new-id", "token": "new-token"}
+        )
+        creds_response = AsyncMock()
+        creds_response.status = 200
+        creds_response.json = AsyncMock(return_value={"Credentials": fresh_creds})
+
+        get_ctx = AsyncMock()
+        get_ctx.__aenter__.return_value = cognito_response
+        mock_session.get.return_value = get_ctx
+
+        post_ctx = AsyncMock()
+        post_ctx.__aenter__.return_value = creds_response
+        mock_session.post.return_value = post_ctx
+
+        result = await auth.get_aws_credentials()
+
+        assert result["AccessKeyId"] == "NEW_KEY"
+        assert auth._cognito_identity_id == "new-id"
+
+    async def test_valid_credentials_are_returned_from_cache(
+        self, mock_whirlpool_auth: MagicMock, mock_session: MagicMock
+    ) -> None:
+        """Credentials that haven't expired yet should be returned
+        directly from cache without any HTTP calls."""
+
+        auth = Auth(mock_whirlpool_auth, mock_session)
+
+        valid_creds = {
+            "AccessKeyId": "CACHED_KEY",
+            "SecretKey": "CACHED_SECRET",
+            "SessionToken": "CACHED_TOKEN",
+            "Expiration": time.time() + 3600,
+        }
+        auth._aws_credentials = valid_creds
+
+        result = await auth.get_aws_credentials()
+
+        assert result["AccessKeyId"] == "CACHED_KEY"
+        mock_session.get.assert_not_called()
+        mock_session.post.assert_not_called()

--- a/tests/awsiot/test_mqttclient_reconnect.py
+++ b/tests/awsiot/test_mqttclient_reconnect.py
@@ -7,12 +7,15 @@ paho's own auto-reconnect reuses the original signed URL, which expires.
 """
 
 import asyncio
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from whirlpool.awsiot.mqttclient import MqttClient
+
+LOGGER_NAME = "whirlpool.awsiot.mqttclient"
 
 
 @pytest.fixture
@@ -103,6 +106,142 @@ class TestReconnect:
         mock_aws_auth.create_signed_url.assert_called()
         assert client.is_connected()
         paho_clients[-1].subscribe.assert_any_call("topic/a", qos=1)
+
+        await client.disconnect()
+
+    async def test_successful_reconnect_uses_quiet_progress_logs(
+        self,
+        mock_aws_auth: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Retry progress and success should not flood HA warnings."""
+
+        caplog.set_level(logging.DEBUG, logger=LOGGER_NAME)
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            0.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        _fire_failure_disconnect(paho_clients[0])
+        for _ in range(100):
+            await _flush()
+            if len(paho_clients) >= 2:
+                _fire_connack(paho_clients[-1])
+            if client.is_connected() and len(paho_clients) >= 2:
+                break
+
+        records = [record for record in caplog.records if record.name == LOGGER_NAME]
+        assert any(
+            record.levelno == logging.WARNING
+            and record.message.startswith("MQTT unexpected disconnect")
+            for record in records
+        )
+        assert any(
+            record.levelno == logging.DEBUG
+            and record.message == "MQTT reconnecting in 0.0s"
+            for record in records
+        )
+        assert any(
+            record.levelno == logging.INFO
+            and record.message == "MQTT reconnected successfully"
+            for record in records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and record.message.startswith("MQTT reconnecting in")
+            for record in records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and record.message == "MQTT reconnected successfully"
+            for record in records
+        )
+
+        await client.disconnect()
+
+    async def test_failed_reconnect_logs_concise_warning_and_debug_traceback(
+        self,
+        mock_aws_auth: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Repeated reconnect failures should avoid warning-level tracebacks."""
+
+        caplog.set_level(logging.DEBUG, logger=LOGGER_NAME)
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            0.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        mock_aws_auth.create_signed_url.side_effect = RuntimeError(
+            "temporary auth failure"
+        )
+        _fire_failure_disconnect(paho_clients[0])
+
+        for _ in range(100):
+            await _flush()
+            if any(
+                "temporary auth failure" in record.message
+                for record in caplog.records
+            ):
+                break
+
+        records = [record for record in caplog.records if record.name == LOGGER_NAME]
+        assert any(
+            record.levelno == logging.WARNING
+            and record.message
+            == "MQTT reconnect attempt failed: temporary auth failure"
+            and record.exc_info is None
+            for record in records
+        )
+        assert any(
+            record.levelno == logging.DEBUG
+            and record.message == "MQTT reconnect attempt traceback"
+            and record.exc_info is not None
+            for record in records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and record.message == "MQTT reconnect attempt raised"
+            for record in records
+        )
 
         await client.disconnect()
 

--- a/tests/awsiot/test_mqttclient_reconnect.py
+++ b/tests/awsiot/test_mqttclient_reconnect.py
@@ -1,0 +1,184 @@
+"""Tests for MqttClient auto-reconnect on unexpected disconnect.
+
+The real-world failure that motivates these: a single SigV4 websocket
+disconnect (roaming DHCP lease, broker-initiated drop, etc.) used to
+leave the client permanently offline until the host restarted, because
+paho's own auto-reconnect reuses the original signed URL, which expires.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from whirlpool.awsiot.mqttclient import MqttClient
+
+
+@pytest.fixture
+def mock_aws_auth() -> AsyncMock:
+    auth = AsyncMock()
+    auth.create_signed_url.return_value = (
+        "wss://wt.applianceconnect.net/mqtt?X-Amz-Algorithm=fake"
+    )
+    auth.get_cognito_identity_id.return_value = "fake-identity-id"
+    return auth
+
+
+async def _flush() -> None:
+    # Let scheduled tasks and soon-callbacks drain.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+def _fire_connack(paho_instance: MagicMock) -> None:
+    paho_instance.on_connect(
+        paho_instance, None, MagicMock(), MagicMock(is_failure=False), None
+    )
+
+
+def _fire_failure_disconnect(paho_instance: MagicMock) -> None:
+    paho_instance.on_disconnect(
+        paho_instance, None, MagicMock(), MagicMock(is_failure=True), None
+    )
+
+
+class TestReconnect:
+    async def test_unexpected_disconnect_rebuilds_client_and_resubscribes(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After an unexpected MQTT disconnect the client must rebuild
+        itself: fetch a fresh signed URL, create a new paho client, and
+        reapply all prior subscriptions. Without this, a single websocket
+        drop leaves the integration permanently unavailable until the host
+        restarts."""
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            instance.publish.return_value = None
+            instance.subscribe.return_value = None
+            instance.unsubscribe.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        # Collapse the backoff so the reconnect loop doesn't slow tests.
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            0.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        client.subscribe("topic/a")
+
+        mock_aws_auth.create_signed_url.reset_mock()
+
+        _fire_failure_disconnect(paho_clients[0])
+
+        # Drive the reconnect to completion. We don't know exactly when
+        # each await in connect() resolves, so keep flushing and firing
+        # on_connect on the newest paho client until is_connected is set.
+        for _ in range(100):
+            await _flush()
+            if client.is_connected():
+                break
+            if len(paho_clients) >= 2:
+                _fire_connack(paho_clients[-1])
+
+        assert len(paho_clients) >= 2, (
+            f"expected reconnect to build a new paho client, got "
+            f"{len(paho_clients)}"
+        )
+        mock_aws_auth.create_signed_url.assert_called()
+        assert client.is_connected()
+        paho_clients[-1].subscribe.assert_any_call("topic/a", qos=1)
+
+        await client.disconnect()
+
+    async def test_clean_disconnect_does_not_trigger_reconnect(
+        self, mock_aws_auth: AsyncMock
+    ) -> None:
+        """A clean disconnect (is_failure=False) means the broker or we
+        intentionally closed the connection; don't try to reconnect."""
+
+        fake_paho = MagicMock(name="paho.Client")
+        fake_paho.connect.return_value = None
+
+        with patch(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", return_value=fake_paho
+        ):
+            client = MqttClient(mock_aws_auth)
+            connect_task = asyncio.create_task(client.connect())
+            await _flush()
+            _fire_connack(fake_paho)
+            await _flush()
+            assert await connect_task is True
+
+            mock_aws_auth.create_signed_url.reset_mock()
+
+            fake_paho.on_disconnect(
+                fake_paho, None, MagicMock(), MagicMock(is_failure=False), None
+            )
+            for _ in range(10):
+                await _flush()
+
+            mock_aws_auth.create_signed_url.assert_not_called()
+            assert not client.is_connected()
+
+            await client.disconnect()
+
+    async def test_explicit_disconnect_cancels_pending_reconnect(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling disconnect() must cancel any in-flight reconnect loop
+        so the caller can tear down cleanly."""
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        # Use a non-zero backoff so the reconnect loop is still in
+        # asyncio.sleep when we call disconnect().
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            60.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        _fire_failure_disconnect(paho_clients[0])
+        for _ in range(10):
+            await _flush()
+
+        # Reconnect task should be scheduled and sleeping.
+        assert client._reconnect_task is not None  # pyright: ignore[reportPrivateUsage]
+        assert not client._reconnect_task.done()  # pyright: ignore[reportPrivateUsage]
+
+        await client.disconnect()
+
+        assert client._reconnect_task is None  # pyright: ignore[reportPrivateUsage]
+        # No second paho client should have been built.
+        assert len(paho_clients) == 1

--- a/tests/awsiot/test_mqttclient_reconnect.py
+++ b/tests/awsiot/test_mqttclient_reconnect.py
@@ -138,6 +138,101 @@ class TestReconnect:
 
             await client.disconnect()
 
+    async def test_reconnect_keeps_client_id_stable(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reconnect must keep the same MQTT client ID.
+
+        Appliances build response subscriptions from `client_id`. If a
+        reconnect changes it, we resubscribe the old response topic but
+        publish requests using the new response topic.
+        """
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            0.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+        first_client_id = client.client_id
+
+        _fire_failure_disconnect(paho_clients[0])
+
+        for _ in range(100):
+            await _flush()
+            if len(paho_clients) >= 2:
+                _fire_connack(paho_clients[-1])
+            if client.is_connected() and len(paho_clients) >= 2:
+                break
+
+        assert client.is_connected()
+        assert client.client_id == first_client_id
+
+        await client.disconnect()
+
+    async def test_stale_disconnect_from_old_client_is_ignored(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Callbacks from a replaced paho client must not affect state."""
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory
+        )
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.RECONNECT_BACKOFF_INITIAL_SECONDS",
+            0.0,
+        )
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        _fire_failure_disconnect(paho_clients[0])
+        for _ in range(100):
+            await _flush()
+            if len(paho_clients) >= 2:
+                _fire_connack(paho_clients[-1])
+            if client.is_connected() and len(paho_clients) >= 2:
+                break
+
+        assert client.is_connected()
+
+        paho_clients[0].on_disconnect(
+            paho_clients[0], None, MagicMock(), MagicMock(is_failure=False), None
+        )
+        await _flush()
+
+        assert client.is_connected()
+
+        await client.disconnect()
+
     async def test_explicit_disconnect_cancels_pending_reconnect(
         self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/awsiot/test_mqttclient_reconnect.py
+++ b/tests/awsiot/test_mqttclient_reconnect.py
@@ -372,6 +372,99 @@ class TestReconnect:
 
         await client.disconnect()
 
+    async def test_connect_disables_paho_auto_reconnect(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """We drive reconnects ourselves (to re-sign the URL), so paho's own
+        auto-reconnect must be disabled via the public constructor arg."""
+
+        paho_clients: list[MagicMock] = []
+        captured_kwargs: list[dict[str, Any]] = []
+
+        def paho_factory(**kwargs: Any) -> MagicMock:
+            captured_kwargs.append(kwargs)
+            instance = MagicMock(name="paho.Client")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr("whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory)
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        assert captured_kwargs[0]["reconnect_on_failure"] is False
+
+        await client.disconnect()
+
+    async def test_connect_reentry_tears_down_previous_client(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling connect() again must tear down the previous paho client so
+        its loop thread and socket are not leaked."""
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr("whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory)
+
+        client = MqttClient(mock_aws_auth)
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[0])
+        await _flush()
+        assert await connect_task is True
+
+        # Second connect() without a disconnect() in between.
+        connect_task = asyncio.create_task(client.connect())
+        await _flush()
+        _fire_connack(paho_clients[-1])
+        await _flush()
+        assert await connect_task is True
+
+        assert len(paho_clients) == 2
+        paho_clients[0].loop_stop.assert_called()
+        paho_clients[0].disconnect.assert_called()
+
+        await client.disconnect()
+
+    async def test_connect_timeout_disconnects_paho_client(
+        self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On connect timeout (no CONNACK) the paho client must be stopped and
+        disconnected so we don't leave the socket/loop thread behind."""
+
+        paho_clients: list[MagicMock] = []
+
+        def paho_factory(**_kwargs: Any) -> MagicMock:
+            instance = MagicMock(name=f"paho.Client[{len(paho_clients)}]")
+            instance.connect.return_value = None
+            paho_clients.append(instance)
+            return instance
+
+        monkeypatch.setattr("whirlpool.awsiot.mqttclient.mqtt.Client", paho_factory)
+        monkeypatch.setattr(
+            "whirlpool.awsiot.mqttclient.CONNECT_TIMEOUT_SECONDS", 0.01
+        )
+
+        client = MqttClient(mock_aws_auth)
+        # Never fire CONNACK, so connect() hits the timeout path.
+        assert await client.connect() is False
+
+        assert len(paho_clients) == 1
+        paho_clients[0].loop_stop.assert_called()
+        paho_clients[0].disconnect.assert_called()
+        assert not client.is_connected()
+
     async def test_explicit_disconnect_cancels_pending_reconnect(
         self, mock_aws_auth: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/whirlpool/awsiot/auth.py
+++ b/whirlpool/awsiot/auth.py
@@ -1,6 +1,7 @@
 """AWS Cognito authentication for Whirlpool appliances."""
 
 import logging
+import time
 from typing import Any
 
 import aiohttp
@@ -81,10 +82,16 @@ class Auth:
         """
         Get temporary AWS credentials for IoT access.
 
-        The result is cached.
+        The result is cached until expiration.
         """
         if self._aws_credentials:
-            return self._aws_credentials
+            expiration = self._aws_credentials.get("Expiration", 0)
+            if time.time() < expiration - 60:
+                return self._aws_credentials
+            LOGGER.info("AWS credentials expired, refreshing")
+            self._aws_credentials = None
+            self._cognito_identity_id = None
+            self._cognito_token = None
 
         identity_id = await self.get_cognito_identity_id()
         if not identity_id or not self._cognito_token:

--- a/whirlpool/awsiot/mqttclient.py
+++ b/whirlpool/awsiot/mqttclient.py
@@ -45,7 +45,7 @@ class MqttClient:
         self._reconnect_task: asyncio.Task[None] | None = None
         self._shutting_down: bool = False
 
-    async def connect(self) -> bool:
+    async def connect(self, *, log_failures: bool = True) -> bool:
         """Connect to the MQTT broker."""
         self._shutting_down = False
         self._connected.clear()
@@ -88,7 +88,10 @@ class MqttClient:
         try:
             client.connect(MQTT_ENDPOINT, port=443, keepalive=30)
         except Exception as e:
-            LOGGER.error("Failed to connect to MQTT broker: %s", e)
+            if log_failures:
+                LOGGER.error("Failed to connect to MQTT broker: %s", e)
+            else:
+                LOGGER.debug("Failed to connect to MQTT broker", exc_info=True)
             return False
 
         self._client = client
@@ -97,7 +100,10 @@ class MqttClient:
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=10.0)
         except TimeoutError:
-            LOGGER.error("MQTT connection timeout")
+            if log_failures:
+                LOGGER.error("MQTT connection timeout")
+            else:
+                LOGGER.debug("MQTT connection timeout during reconnect")
             client.loop_stop()
             self._client = None
             return False
@@ -256,7 +262,7 @@ class MqttClient:
         """
         delay = RECONNECT_BACKOFF_INITIAL_SECONDS
         while not self._shutting_down:
-            LOGGER.warning("MQTT reconnecting in %.1fs", delay)
+            LOGGER.debug("MQTT reconnecting in %.1fs", delay)
             try:
                 await asyncio.sleep(delay)
             except asyncio.CancelledError:
@@ -277,17 +283,23 @@ class MqttClient:
                 except Exception:
                     LOGGER.debug("Error disconnecting old MQTT client", exc_info=True)
 
+            failure_logged = False
             try:
-                ok = await self.connect()
+                ok = await self.connect(log_failures=False)
             except asyncio.CancelledError:
                 return
-            except Exception:
-                LOGGER.exception("MQTT reconnect attempt raised")
+            except Exception as e:
+                LOGGER.warning("MQTT reconnect attempt failed: %s", e)
+                LOGGER.debug("MQTT reconnect attempt traceback", exc_info=True)
                 ok = False
+                failure_logged = True
 
             if ok:
-                LOGGER.warning("MQTT reconnected successfully")
+                LOGGER.info("MQTT reconnected successfully")
                 return
+
+            if not failure_logged:
+                LOGGER.warning("MQTT reconnect attempt failed")
 
             delay = min(delay * 2 if delay > 0 else 1.0, RECONNECT_BACKOFF_CAP_SECONDS)
 

--- a/whirlpool/awsiot/mqttclient.py
+++ b/whirlpool/awsiot/mqttclient.py
@@ -19,6 +19,7 @@ from .auth import Auth
 LOGGER = logging.getLogger(__name__)
 
 MQTT_ENDPOINT = "wt.applianceconnect.net"
+CONNECT_TIMEOUT_SECONDS = 10.0
 RECONNECT_BACKOFF_INITIAL_SECONDS = 1.0
 RECONNECT_BACKOFF_CAP_SECONDS = 30.0
 
@@ -45,10 +46,32 @@ class MqttClient:
         self._reconnect_task: asyncio.Task[None] | None = None
         self._shutting_down: bool = False
 
-    async def connect(self, *, log_failures: bool = True) -> bool:
+    def _teardown_client(self) -> None:
+        """Best-effort stop and disconnect of the current paho client, if any.
+
+        Drops the reference first so callbacks from the old client are treated
+        as stale by `_is_active_client`.
+        """
+        if self._client is None:
+            return
+        old = self._client
+        self._client = None
+        try:
+            old.loop_stop()
+        except Exception:
+            LOGGER.debug("Error stopping MQTT client loop", exc_info=True)
+        try:
+            old.disconnect()
+        except Exception:
+            LOGGER.debug("Error disconnecting MQTT client", exc_info=True)
+
+    async def connect(self) -> bool:
         """Connect to the MQTT broker."""
         self._shutting_down = False
         self._connected.clear()
+        # Tear down any previous client so we don't leak its loop thread/socket
+        # if connect() is called again without a disconnect() in between.
+        self._teardown_client()
 
         signed_url = await self._aws_auth.create_signed_url(MQTT_ENDPOINT)
         client_id = await self._generate_client_id()
@@ -61,8 +84,8 @@ class MqttClient:
             transport="websockets",
             protocol=MQTTProtocolVersion.MQTTv311,
             callback_api_version=CallbackAPIVersion.VERSION2,
+            reconnect_on_failure=False,
         )
-        client._reconnect_on_failure = False  # type: ignore[attr-defined]  # noqa: SLF001
         client.on_connect = self._on_connect
         client.on_message = self._on_message
         client.on_disconnect = self._on_disconnect
@@ -87,25 +110,20 @@ class MqttClient:
 
         try:
             client.connect(MQTT_ENDPOINT, port=443, keepalive=30)
-        except Exception as e:
-            if log_failures:
-                LOGGER.error("Failed to connect to MQTT broker: %s", e)
-            else:
-                LOGGER.debug("Failed to connect to MQTT broker", exc_info=True)
+        except Exception:
+            LOGGER.debug("Failed to connect to MQTT broker", exc_info=True)
             return False
 
         self._client = client
         client.loop_start()
 
         try:
-            await asyncio.wait_for(self._connected.wait(), timeout=10.0)
+            await asyncio.wait_for(
+                self._connected.wait(), timeout=CONNECT_TIMEOUT_SECONDS
+            )
         except TimeoutError:
-            if log_failures:
-                LOGGER.error("MQTT connection timeout")
-            else:
-                LOGGER.debug("MQTT connection timeout during reconnect")
-            client.loop_stop()
-            self._client = None
+            LOGGER.debug("MQTT connection timeout")
+            self._teardown_client()
             return False
 
         self._client_id = client_id
@@ -123,10 +141,7 @@ class MqttClient:
                 pass
             self._reconnect_task = None
 
-        if self._client:
-            self._client.loop_stop()
-            self._client.disconnect()
-            self._client = None
+        self._teardown_client()
         self._connected.clear()
         self._client_id = None
 
@@ -255,10 +270,10 @@ class MqttClient:
         """Rebuild the MQTT client with fresh auth, using exponential backoff.
 
         Each attempt drives the full connect() path, which fetches a new
-        SigV4-signed websocket URL. The old paho client (if any) is stopped
-        before building the new one. `_resubscribe_and_set_connected`
-        (called from on_connect) reapplies `self._subscribed_topics` so
-        existing subscriptions survive the rebuild.
+        SigV4-signed websocket URL and tears down the old paho client before
+        building the new one. `_resubscribe_and_set_connected` (called from
+        on_connect) reapplies `self._subscribed_topics` so existing
+        subscriptions survive the rebuild.
         """
         delay = RECONNECT_BACKOFF_INITIAL_SECONDS
         while not self._shutting_down:
@@ -271,37 +286,17 @@ class MqttClient:
             if self._shutting_down:
                 return
 
-            if self._client is not None:
-                old = self._client
-                self._client = None
-                try:
-                    old.loop_stop()
-                except Exception:
-                    LOGGER.debug("Error stopping old MQTT client loop", exc_info=True)
-                try:
-                    old.disconnect()
-                except Exception:
-                    LOGGER.debug("Error disconnecting old MQTT client", exc_info=True)
-
-            failure_logged = False
             try:
-                ok = await self.connect(log_failures=False)
+                if await self.connect():
+                    LOGGER.info("MQTT reconnected successfully")
+                    return
             except asyncio.CancelledError:
                 return
             except Exception as e:
                 LOGGER.warning("MQTT reconnect attempt failed: %s", e)
                 LOGGER.debug("MQTT reconnect attempt traceback", exc_info=True)
-                ok = False
-                failure_logged = True
 
-            if ok:
-                LOGGER.info("MQTT reconnected successfully")
-                return
-
-            if not failure_logged:
-                LOGGER.warning("MQTT reconnect attempt failed")
-
-            delay = min(delay * 2 if delay > 0 else 1.0, RECONNECT_BACKOFF_CAP_SECONDS)
+            delay = min(delay * 2, RECONNECT_BACKOFF_CAP_SECONDS)
 
     def _on_subscribe(
         self,

--- a/whirlpool/awsiot/mqttclient.py
+++ b/whirlpool/awsiot/mqttclient.py
@@ -19,6 +19,8 @@ from .auth import Auth
 LOGGER = logging.getLogger(__name__)
 
 MQTT_ENDPOINT = "wt.applianceconnect.net"
+RECONNECT_BACKOFF_INITIAL_SECONDS = 1.0
+RECONNECT_BACKOFF_CAP_SECONDS = 30.0
 
 
 def _generate_client_id(identity_id: str) -> str:
@@ -44,6 +46,8 @@ class MqttClient:
         self._client_id: str | None = None
 
         self._loop = asyncio.get_running_loop()
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._shutting_down: bool = False
 
     async def connect(self) -> bool:
         """Connect to the MQTT broker."""
@@ -104,6 +108,16 @@ class MqttClient:
 
     async def disconnect(self) -> None:
         """Disconnect from the MQTT broker."""
+        self._shutting_down = True
+
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except asyncio.CancelledError:
+                pass
+            self._reconnect_task = None
+
         if self._client:
             self._client.loop_stop()
             self._client.disconnect()
@@ -207,6 +221,59 @@ class MqttClient:
             LOGGER.debug("MQTT disconnected cleanly")
 
         self._loop.call_soon_threadsafe(self._connected.clear)
+
+        if reason_code.is_failure:
+            self._loop.call_soon_threadsafe(self._schedule_reconnect)
+
+    def _schedule_reconnect(self) -> None:
+        """Start a reconnect task if one isn't already running."""
+        if self._shutting_down:
+            return
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return
+        self._reconnect_task = self._loop.create_task(self._reconnect_loop())
+
+    async def _reconnect_loop(self) -> None:
+        """Rebuild the MQTT client with fresh auth, using exponential backoff.
+
+        Each attempt drives the full connect() path, which fetches a new
+        SigV4-signed websocket URL. The old paho client (if any) is stopped
+        before building the new one. `_resubscribe_and_set_connected`
+        (called from on_connect) reapplies `self._subscribed_topics` so
+        existing subscriptions survive the rebuild.
+        """
+        delay = RECONNECT_BACKOFF_INITIAL_SECONDS
+        while not self._shutting_down:
+            LOGGER.info("MQTT reconnecting in %.1fs", delay)
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+
+            if self._shutting_down:
+                return
+
+            if self._client is not None:
+                old = self._client
+                self._client = None
+                try:
+                    old.loop_stop()
+                except Exception:
+                    LOGGER.debug("Error stopping old MQTT client loop", exc_info=True)
+
+            try:
+                ok = await self.connect()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                LOGGER.exception("MQTT reconnect attempt raised")
+                ok = False
+
+            if ok:
+                LOGGER.info("MQTT reconnected")
+                return
+
+            delay = min(delay * 2 if delay > 0 else 1.0, RECONNECT_BACKOFF_CAP_SECONDS)
 
     def _on_subscribe(
         self,

--- a/whirlpool/awsiot/mqttclient.py
+++ b/whirlpool/awsiot/mqttclient.py
@@ -23,12 +23,6 @@ RECONNECT_BACKOFF_INITIAL_SECONDS = 1.0
 RECONNECT_BACKOFF_CAP_SECONDS = 30.0
 
 
-def _generate_client_id(identity_id: str) -> str:
-    """Generate a client ID in the format used by the Android app."""
-    random_suffix = secrets.token_hex(8)  # 16 hex chars
-    return f"{identity_id}_{random_suffix}"
-
-
 class MqttClient:
     """Async MQTT client for Whirlpool appliance communication."""
 
@@ -44,6 +38,8 @@ class MqttClient:
         self._connected = asyncio.Event()
         self._subscribed_topics: set[str] = set()
         self._client_id: str | None = None
+        # Keep response topics stable across reconnects.
+        self._client_id_suffix: str = secrets.token_hex(8)
 
         self._loop = asyncio.get_running_loop()
         self._reconnect_task: asyncio.Task[None] | None = None
@@ -51,6 +47,7 @@ class MqttClient:
 
     async def connect(self) -> bool:
         """Connect to the MQTT broker."""
+        self._shutting_down = False
         self._connected.clear()
 
         signed_url = await self._aws_auth.create_signed_url(MQTT_ENDPOINT)
@@ -94,8 +91,8 @@ class MqttClient:
             LOGGER.error("Failed to connect to MQTT broker: %s", e)
             return False
 
-        client.loop_start()
         self._client = client
+        client.loop_start()
 
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=10.0)
@@ -125,6 +122,7 @@ class MqttClient:
             self._client.disconnect()
             self._client = None
         self._connected.clear()
+        self._client_id = None
 
     def is_connected(self) -> bool:
         """Check if connected to the MQTT broker."""
@@ -160,17 +158,23 @@ class MqttClient:
         identity_id = await self._aws_auth.get_cognito_identity_id()
         if not identity_id:
             raise RuntimeError("Failed to get Cognito identity ID")
-        return _generate_client_id(identity_id)
+        return f"{identity_id}_{self._client_id_suffix}"
+
+    def _is_active_client(self, client: mqtt.Client) -> bool:
+        return self._client is client
 
     def _on_connect(
         self,
-        _client: mqtt.Client,
+        client: mqtt.Client,
         _userdata: Any,
         _connect_flags: mqtt.ConnectFlags,
         reason_code: ReasonCode,
         _properties: Properties | None = None,
     ) -> None:
         """Callback when connected to MQTT broker."""
+        if not self._is_active_client(client):
+            LOGGER.debug("Ignoring on_connect from stale MQTT client")
+            return
         if reason_code.is_failure:
             LOGGER.error("MQTT connection failed: %s", reason_code)
             return
@@ -192,9 +196,12 @@ class MqttClient:
         self._connected.set()
 
     def _on_message(
-        self, _client: mqtt.Client, _userdata: Any, msg: mqtt.MQTTMessage
+        self, client: mqtt.Client, _userdata: Any, msg: mqtt.MQTTMessage
     ) -> None:
         """Callback when a message is received."""
+        if not self._is_active_client(client):
+            LOGGER.debug("Ignoring message from stale MQTT client on %s", msg.topic)
+            return
         LOGGER.debug("MQTT message on topic: %s", msg.topic)
 
         try:
@@ -210,13 +217,16 @@ class MqttClient:
 
     def _on_disconnect(
         self,
-        _client: mqtt.Client,
+        client: mqtt.Client,
         _userdata: Any,
         _disconnect_flags: mqtt.DisconnectFlags,
         reason_code: ReasonCode,
         _properties: Properties | None = None,
     ) -> None:
         """Callback when disconnected from MQTT broker."""
+        if not self._is_active_client(client):
+            LOGGER.debug("Ignoring on_disconnect from stale MQTT client")
+            return
         if reason_code.is_failure:
             LOGGER.warning("MQTT unexpected disconnect: %s", reason_code)
         else:
@@ -262,6 +272,10 @@ class MqttClient:
                     old.loop_stop()
                 except Exception:
                     LOGGER.debug("Error stopping old MQTT client loop", exc_info=True)
+                try:
+                    old.disconnect()
+                except Exception:
+                    LOGGER.debug("Error disconnecting old MQTT client", exc_info=True)
 
             try:
                 ok = await self.connect()
@@ -279,11 +293,14 @@ class MqttClient:
 
     def _on_subscribe(
         self,
-        _client: mqtt.Client,
+        client: mqtt.Client,
         _userdata: Any,
         mid: int,
         granted_qos: list[ReasonCode],
         _properties: Properties | None = None,
     ) -> None:
         """Callback when subscription is confirmed."""
+        if not self._is_active_client(client):
+            LOGGER.debug("Ignoring subscribe ack from stale MQTT client")
+            return
         LOGGER.debug("MQTT subscription confirmed (mid: %d, QoS: %s)", mid, granted_qos)

--- a/whirlpool/awsiot/mqttclient.py
+++ b/whirlpool/awsiot/mqttclient.py
@@ -51,6 +51,7 @@ class MqttClient:
 
     async def connect(self) -> bool:
         """Connect to the MQTT broker."""
+        self._connected.clear()
 
         signed_url = await self._aws_auth.create_signed_url(MQTT_ENDPOINT)
         client_id = await self._generate_client_id()
@@ -64,6 +65,7 @@ class MqttClient:
             protocol=MQTTProtocolVersion.MQTTv311,
             callback_api_version=CallbackAPIVersion.VERSION2,
         )
+        client._reconnect_on_failure = False  # type: ignore[attr-defined]  # noqa: SLF001
         client.on_connect = self._on_connect
         client.on_message = self._on_message
         client.on_disconnect = self._on_disconnect
@@ -244,7 +246,7 @@ class MqttClient:
         """
         delay = RECONNECT_BACKOFF_INITIAL_SECONDS
         while not self._shutting_down:
-            LOGGER.info("MQTT reconnecting in %.1fs", delay)
+            LOGGER.warning("MQTT reconnecting in %.1fs", delay)
             try:
                 await asyncio.sleep(delay)
             except asyncio.CancelledError:
@@ -270,7 +272,7 @@ class MqttClient:
                 ok = False
 
             if ok:
-                LOGGER.info("MQTT reconnected")
+                LOGGER.warning("MQTT reconnected successfully")
                 return
 
             delay = min(delay * 2 if delay > 0 else 1.0, RECONNECT_BACKOFF_CAP_SECONDS)


### PR DESCRIPTION
## Summary

`MqttClient._on_disconnect` previously logged unexpected failures and cleared connection state, but never recovered. Paho's own reconnect path is not enough here because `connect()` installs a SigV4-signed websocket URL via `ws_set_options(path=...)`; reused signatures eventually expire.

This PR makes unexpected AWS IoT MQTT disconnects self-healing by rebuilding the paho client with fresh AWS credentials and a fresh SigV4-signed websocket URL.

## Evidence

Observed failure mode:

- One log line: `MQTT unexpected disconnect: Unspecified error`
- About 20 minutes later, AWS IoT entities went unavailable
- Hundreds of `Cannot publish, MQTT client not connected` and initial-state timeout warnings followed
- Recovery required restarting the host application

## Fix

On a failure disconnect, schedule a reconnect task that:

1. Stops the old paho client best-effort
2. Sleeps with exponential backoff (`1s -> 30s` cap)
3. Calls `self.connect()`, which fetches fresh AWS credentials when needed and creates a fresh SigV4-signed URL
4. Resubscribes existing `_subscribed_topics`

Additional reconnect hardening included here:

- Cached AWS credentials are invalidated when their `Expiration` timestamp is reached, so reconnects do not sign URLs with expired Cognito credentials.
- Paho auto-reconnect is disabled because it reuses the original signed websocket URL.
- `_connected` is cleared at the start of `connect()` to avoid stale event state.
- MQTT client IDs remain stable across reconnects, keeping appliance response topics valid.
- Callbacks from replaced/stale paho clients are ignored, so an old client cannot clear or disturb the active connection state.
- Explicit `disconnect()` cancels an in-flight reconnect task and tears down cleanly.

## Tests

`tests/awsiot/test_mqttclient_reconnect.py` covers:

- unexpected disconnect rebuilds the paho client and resubscribes
- clean disconnect does not reconnect
- reconnect keeps the MQTT client ID stable
- stale disconnect callbacks from old clients are ignored
- explicit disconnect cancels a pending reconnect

`tests/awsiot/test_auth.py` covers:

- expired AWS Cognito credentials are refreshed
- valid AWS Cognito credentials are reused from cache

## Local Verification

- [x] `python -m pytest tests/awsiot/test_auth.py tests/awsiot/test_mqttclient_reconnect.py tests/test_microwave.py -q` - 21 passed
- [x] `python -m ruff check whirlpool/awsiot/auth.py whirlpool/awsiot/mqttclient.py tests/awsiot/test_auth.py tests/awsiot/test_mqttclient_reconnect.py tests/test_microwave.py` - passed
- [x] `basedpyright whirlpool/awsiot/auth.py whirlpool/awsiot/mqttclient.py tests/awsiot/test_auth.py tests/awsiot/test_mqttclient_reconnect.py tests/test_microwave.py` - 0 errors, 0 warnings, 0 notes
