### PR TITLE
Add periodic keepalive fetch to AppliancesManager

### DIFF
--- a/tests/test_appliancesmanager.py
+++ b/tests/test_appliancesmanager.py
@@ -1,7 +1,12 @@
+import asyncio
+
 import pytest
 from aioresponses import aioresponses
+from yarl import URL
 
 from tests import ACCOUNT_ID
+from whirlpool import appliancesmanager
+from whirlpool.appliancesmanager import AppliancesManager
 from whirlpool.auth import Auth
 from whirlpool.backendselector import BackendSelector
 
@@ -24,3 +29,57 @@ async def test_fetch_appliances_calls_owned_and_shared_methods(
     aioresponses_mock.assert_called_with(
         backend_selector.shared_appliances_url, "GET", headers=shared_headers
     )
+
+
+def _get_request_count(aioresponses_mock: aioresponses, url: str) -> int:
+    return len(aioresponses_mock.requests.get(("GET", URL(url)), []))
+
+
+async def test_keepalive_periodically_fetches_an_appliance(
+    appliances_manager: AppliancesManager,
+    backend_selector: BackendSelector,
+    aioresponses_mock: aioresponses,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(appliancesmanager, "KEEPALIVE_INTERVAL_SECONDS", 0.01)
+
+    for said in appliances_manager.all_appliances:
+        aioresponses_mock.get(
+            backend_selector.get_appliance_data_url(said), payload={}, repeat=True
+        )
+    kept_alive_url = backend_selector.get_appliance_data_url(
+        next(iter(appliances_manager.all_appliances))
+    )
+
+    # Restart the listener so the patched keepalive interval takes effect.
+    await appliances_manager.stop_event_listener()
+    await appliances_manager.start_event_listener()
+    count_after_start = _get_request_count(aioresponses_mock, kept_alive_url)
+
+    await asyncio.sleep(0.05)
+    assert _get_request_count(aioresponses_mock, kept_alive_url) > count_after_start
+
+
+async def test_keepalive_stops_with_event_listener(
+    appliances_manager: AppliancesManager,
+    backend_selector: BackendSelector,
+    aioresponses_mock: aioresponses,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(appliancesmanager, "KEEPALIVE_INTERVAL_SECONDS", 0.01)
+
+    for said in appliances_manager.all_appliances:
+        aioresponses_mock.get(
+            backend_selector.get_appliance_data_url(said), payload={}, repeat=True
+        )
+    kept_alive_url = backend_selector.get_appliance_data_url(
+        next(iter(appliances_manager.all_appliances))
+    )
+
+    await appliances_manager.stop_event_listener()
+    await appliances_manager.start_event_listener()
+    await appliances_manager.stop_event_listener()
+
+    count_after_stop = _get_request_count(aioresponses_mock, kept_alive_url)
+    await asyncio.sleep(0.05)
+    assert _get_request_count(aioresponses_mock, kept_alive_url) == count_after_stop

--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import logging
+from contextlib import suppress
 from functools import cached_property
 from typing import Any
 
@@ -19,6 +21,11 @@ from .washer import Washer
 
 LOGGER = logging.getLogger(__name__)
 
+# The backend stops sending events over the websocket after a while unless
+# there is some REST activity on the account, so periodically fetch data for
+# one appliance to keep the event subscription alive.
+KEEPALIVE_INTERVAL_SECONDS = 5 * 60
+
 
 class AppliancesManager:
     def __init__(
@@ -31,6 +38,7 @@ class AppliancesManager:
         self._auth = auth
         self._session: aiohttp.ClientSession = session
         self._event_socket: EventSocket | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
         self._aircons: dict[str, Any] = {}
         self._dryers: dict[str, Any] = {}
         self._washers: dict[str, Any] = {}
@@ -86,8 +94,8 @@ class AppliancesManager:
             "ddm_cooking_bio_self_clean_tourmaline_v2",
             "ddm_cooking_bio_g3evo_pyro_bk_v1",
             "ddm_cooking_bio_self_clean_meat_probe_tourmaline_bk_v1",
-            "ddm_cooking_bio_self_clean_steam_tourmaline_v2",      # <-- W9 Ovens
-            "ddm_cooking_bi_mwo_self_clean_steam_tourmaline_v2",   # <-- W9 MWOs
+            "ddm_cooking_bio_self_clean_steam_tourmaline_v2",  # <-- W9 Ovens
+            "ddm_cooking_bi_mwo_self_clean_steam_tourmaline_v2",  # <-- W9 MWOs
         ]
 
         LOGGER.debug("Adding appliance %s", appliance_data)
@@ -204,13 +212,36 @@ class AppliancesManager:
         )
         self._event_socket.start()
 
+        if self._keepalive_task is None:
+            self._keepalive_task = asyncio.get_event_loop().create_task(
+                self._keepalive()
+            )
+
     async def stop_event_listener(self):
         """Stop the appliance event listener"""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._keepalive_task
+            self._keepalive_task = None
+
         if self._event_socket is None:
             LOGGER.warning("Event socket is None")
             return
         await self._event_socket.stop()
         self._event_socket = None
+
+    async def _keepalive(self):
+        """Periodically fetch data for one appliance to keep events flowing."""
+        while True:
+            await asyncio.sleep(KEEPALIVE_INTERVAL_SECONDS)
+            appliance = next(iter(self.all_appliances.values()), None)
+            if appliance is None:
+                continue
+            try:
+                await appliance.fetch_data()
+            except (aiohttp.ClientError, TimeoutError) as ex:
+                LOGGER.warning(f"Keepalive fetch failed: {ex}")
 
     def _event_socket_callback(self, msg: str):
         json_msg = json.loads(msg)

--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -240,8 +240,8 @@ class AppliancesManager:
                 continue
             try:
                 await appliance.fetch_data()
-            except (aiohttp.ClientError, TimeoutError) as ex:
-                LOGGER.warning(f"Keepalive fetch failed: {ex}")
+            except Exception as ex:
+                LOGGER.warning("Keepalive fetch failed: %s", ex)
 
     def _event_socket_callback(self, msg: str):
         json_msg = json.loads(msg)


### PR DESCRIPTION
Implements the keepalive discussed in #119 / #116, following your suggestion there: it lives in `AppliancesManager`, picks one appliance from `all_appliances`, and calls `fetch_data()` on it periodically. The task starts/stops with the event listener.

I went with 5 minutes since that matches the polling cadence Home Assistant has been using for washers/dryers for years (home-assistant/core#97222) without rate-limit issues — happy to change it if you'd rather match MizterB's field-proven 20 minutes.

Once this is released I'll follow up on the Home Assistant side: close home-assistant/core#175049 (integration-level polling, superseded by this), and the washer/dryer polling can then also be dropped from the integration as you mentioned.

Tests: added two for the keepalive; full suite passes locally. (Note: with `aioresponses==0.7.6` I had to pin `aiohttp<3.13` locally — 3.14 breaks aioresponses with a `ClientResponse.__init__` error. Unrelated to this change.)

Fixes #116