### PR TITLE
Bound aiohttp below 3.14 for tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 -r requirements.txt
 aioconsole>=0.3.1
 aioresponses==0.7.6
+# aioresponses does not support aiohttp 3.14 yet (ClientResponse.__init__ changed)
+aiohttp<3.14
 pytest>=6.2.0
 pytest-asyncio>=0.15.0
 pytest-mock>=3.6.0


### PR DESCRIPTION
CI currently errors on every test for any PR (see the pytest jobs on #131): `aioresponses` — including the latest 0.7.9 — fails on aiohttp 3.14 with `ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'`, and the dev requirements leave aiohttp unbounded, so fresh CI installs now pick up 3.14.

This bounds aiohttp below 3.14 in the dev requirements only (the library requirement is unchanged). Verified locally: the full suite passes on aiohttp 3.13.2 with aioresponses 0.7.6, and errors out on 3.14.1 with both 0.7.6 and 0.7.9.

Happy to switch this to an aioresponses bump instead once a release supports aiohttp 3.14.