### PR TITLE
test: migrate from aioresponses to aiointercept

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 aioconsole>=0.3.1
-aioresponses==0.7.6
+aiointercept==0.1.8
 pytest>=6.2.0
 pytest-asyncio>=0.15.0
 pytest-mock>=3.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import json
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
 
 import aiohttp
 import pytest
 import pytest_asyncio
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 from whirlpool.appliancesmanager import AppliancesManager
 from whirlpool.auth import Auth
@@ -14,13 +14,13 @@ from whirlpool.types import Brand, Region
 from . import ACCOUNT_ID, DATA_DIR
 
 
-@pytest.fixture
-def aioresponses_mock() -> Generator[aioresponses]:
-    with aioresponses() as m:
+@pytest_asyncio.fixture
+async def aiointercept_mock() -> AsyncGenerator[aiointercept]:
+    async with aiointercept(mock_external_urls=True) as m:
         yield m
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def client_session_fixture() -> AsyncGenerator[aiohttp.ClientSession]:
     session = aiohttp.ClientSession()
     yield session
@@ -44,7 +44,7 @@ async def appliances_manager_fixture(
     auth: Auth,
     backend_selector: BackendSelector,
     client_session_fixture: aiohttp.ClientSession,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
 ) -> AsyncGenerator[AppliancesManager]:
     with open(DATA_DIR / "owned_appliances.json") as f:
         owned_appliance_data = json.load(f)
@@ -55,18 +55,18 @@ async def appliances_manager_fixture(
     with open(DATA_DIR / "mock_data.json") as f:
         mock_data = json.load(f)
 
-    aioresponses_mock.get(
+    aiointercept_mock.get(
         backend_selector.user_details_url, payload={"accountId": ACCOUNT_ID}
     )
-    aioresponses_mock.get(
+    aiointercept_mock.get(
         backend_selector.get_owned_appliances_url(ACCOUNT_ID),
         payload={ACCOUNT_ID: owned_appliance_data},
     )
-    aioresponses_mock.get(
+    aiointercept_mock.get(
         backend_selector.shared_appliances_url, payload=shared_appliance_data
     )
 
-    aioresponses_mock.get(
+    aiointercept_mock.get(
         backend_selector.websocket_url,
         payload={"url": "wss://something"},
         repeat=True,
@@ -78,7 +78,7 @@ async def appliances_manager_fixture(
     await appliances_manager.fetch_appliances()
 
     for said in appliances_manager.all_appliances.keys():
-        aioresponses_mock.get(
+        aiointercept_mock.get(
             backend_selector.get_appliance_data_url(said),
             payload=mock_data[said],
         )

--- a/tests/test_aircon.py
+++ b/tests/test_aircon.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from whirlpool.aircon import Aircon, FanSpeed, Mode
@@ -66,7 +66,7 @@ async def test_setters(
     appliances_manager: AppliancesManager,
     auth: Auth,
     backend_selector: BackendSelector,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
     method: Callable,
     argument: Any,
     expected_json: dict,
@@ -84,19 +84,18 @@ async def test_setters(
         "method": "POST",
         "data": None,
         "json": expected_payload["json"],
-        "allow_redirects": True,
         "headers": auth.create_headers(),
     }
 
     url = backend_selector.appliance_command_url
 
     # add call, call method
-    aioresponses_mock.post(url, payload=expected_payload)
+    aiointercept_mock.post(url, payload=expected_payload)
     assert await method(aircon, argument)
 
     # assert args and length
-    aioresponses_mock.assert_called_with(**post_request_call_kwargs)
-    assert len(aioresponses_mock.requests[("POST", URL(url))]) == 1
+    aiointercept_mock.assert_called_with(**post_request_call_kwargs)
+    assert len(aiointercept_mock.requests[("POST", URL(url))]) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_appliancesmanager.py
+++ b/tests/test_appliancesmanager.py
@@ -1,5 +1,5 @@
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 
 from tests import ACCOUNT_ID
 from whirlpool.auth import Auth
@@ -10,17 +10,17 @@ from whirlpool.backendselector import BackendSelector
 async def test_fetch_appliances_calls_owned_and_shared_methods(
     auth: Auth,
     backend_selector: BackendSelector,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
 ):
     headers = auth.create_headers()
     shared_headers = {**headers, "WP-CLIENT-BRAND": backend_selector.brand.name}
 
-    aioresponses_mock.assert_called_with(
+    aiointercept_mock.assert_called_with(
         backend_selector.get_owned_appliances_url(ACCOUNT_ID),
         "GET",
         headers=headers,
     )
 
-    aioresponses_mock.assert_called_with(
+    aiointercept_mock.assert_called_with(
         backend_selector.shared_appliances_url, "GET", headers=shared_headers
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from tests import ACCOUNT_ID
@@ -32,7 +32,7 @@ def get_auth_data(backend_selector: BackendSelector) -> dict[str, str]:
 
 
 async def test_auth_success(
-    auth: Auth, backend_selector: BackendSelector, aioresponses_mock: aioresponses
+    auth: Auth, backend_selector: BackendSelector, aiointercept_mock: aiointercept
 ):
     mock_resp_data = {
         "access_token": "acess_token_123",
@@ -49,7 +49,7 @@ async def test_auth_success(
 
     # don't need repeat here because the first one will succeed
     # so we will only call this url once
-    aioresponses_mock.post(auth_url, payload=mock_resp_data)
+    aiointercept_mock.post(auth_url, payload=mock_resp_data)
 
     assert await auth.do_auth(store=False)
     assert auth.is_access_token_valid()
@@ -57,22 +57,23 @@ async def test_auth_success(
     assert str(await auth.get_account_id()) == ACCOUNT_ID
 
     # assert that the proper method and url were used
-    assert ("POST", URL(auth_url)) in aioresponses_mock.requests
+    assert ("POST", URL(auth_url)) in aiointercept_mock.requests
 
     # get the calls for the method/url and assert length
-    calls = aioresponses_mock.requests[("POST", URL(auth_url))]
+    calls = aiointercept_mock.requests[("POST", URL(auth_url))]
     assert len(calls) == 1
 
-    # actual call, as a tuple
+    # actual captured request
     call = calls[0]
-    assert call[1]["data"] == get_auth_data(backend_selector)
-    assert call[1]["headers"] == AUTH_HEADERS
+    assert dict(await call.post()) == get_auth_data(backend_selector)
+    for header, value in AUTH_HEADERS.items():
+        assert call.headers.get(header) == value
 
 
 async def test_auth_will_check_all_client_creds(
     auth: Auth,
     backend_selector: BackendSelector,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
     caplog: pytest.LogCaptureFixture,
 ):
     # need to capture at debug level to get status - we don't return status or have any
@@ -88,7 +89,7 @@ async def test_auth_will_check_all_client_creds(
         # (or run out)
         status = HTTPStatus.NOT_FOUND if i != len(client_creds) else HTTPStatus.OK
         expected.append({"status": status})
-        aioresponses_mock.post(auth_url, status=status)
+        aiointercept_mock.post(auth_url, status=status)
 
     assert not await auth.do_auth(store=False)
 
@@ -106,12 +107,12 @@ async def test_auth_will_check_all_client_creds(
 
 
 async def test_auth_bad_credentials(
-    auth: Auth, backend_selector: BackendSelector, aioresponses_mock: aioresponses
+    auth: Auth, backend_selector: BackendSelector, aiointercept_mock: aiointercept
 ):
     auth_url = get_auth_url(backend_selector)
 
     # need to repeat for the multiple client credentials mock
-    aioresponses_mock.post(auth_url, status=HTTPStatus.BAD_REQUEST, repeat=True)
+    aiointercept_mock.post(auth_url, status=HTTPStatus.BAD_REQUEST, repeat=True)
 
     assert not await auth.do_auth(store=False)
 
@@ -120,23 +121,24 @@ async def test_auth_bad_credentials(
     assert auth.get_said_list() is None
 
     # assert that the proper method and url were used
-    assert ("POST", URL(auth_url)) in aioresponses_mock.requests
+    assert ("POST", URL(auth_url)) in aiointercept_mock.requests
 
     # get the calls for the method/url and assert length - should be the same as the
     # number of client credentials
-    calls = aioresponses_mock.requests[("POST", URL(auth_url))]
+    calls = aiointercept_mock.requests[("POST", URL(auth_url))]
     assert len(calls) == len(backend_selector.client_credentials)
 
     call = calls[0]
-    assert call[1]["data"] == get_auth_data(backend_selector)
-    assert call[1]["headers"] == AUTH_HEADERS
+    assert dict(await call.post()) == get_auth_data(backend_selector)
+    for header, value in AUTH_HEADERS.items():
+        assert call.headers.get(header) == value
 
 
 async def test_auth_account_locked(
-    auth: Auth, backend_selector: BackendSelector, aioresponses_mock: aioresponses
+    auth: Auth, backend_selector: BackendSelector, aiointercept_mock: aiointercept
 ):
     auth_url = get_auth_url(backend_selector)
-    aioresponses_mock.post(auth_url, status=HTTPStatus.LOCKED, repeat=True)
+    aiointercept_mock.post(auth_url, status=HTTPStatus.LOCKED, repeat=True)
 
     with pytest.raises(AccountLockedError):
         await auth.do_auth(store=False)
@@ -146,9 +148,9 @@ async def test_auth_account_locked(
 
 
 async def test_user_details_requested_only_once(
-    auth: Auth, backend_selector: BackendSelector, aioresponses_mock: aioresponses
+    auth: Auth, backend_selector: BackendSelector, aiointercept_mock: aiointercept
 ):
-    aioresponses_mock.get(
+    aiointercept_mock.get(
         backend_selector.user_details_url, payload={"accountId": ACCOUNT_ID}
     )
 
@@ -162,19 +164,18 @@ async def test_user_details_requested_only_once(
 
     await auth.get_account_id()
 
-    aioresponses_mock.assert_called_with(
+    aiointercept_mock.assert_called_with(
         backend_selector.user_details_url, "GET", headers=headers
     )
 
     assert auth._auth_dict["accountId"] == ACCOUNT_ID
 
-    # aioresponses_mock.clear does not reset the requests list, so I'm
-    # just checking that the length doesn't change instead
-    curr_request_count = len(aioresponses_mock.requests)
+    # the second call should use the cached account id and issue no request
+    aiointercept_mock.clear()
 
     await auth.get_account_id()
 
-    assert len(aioresponses_mock.requests) == curr_request_count
+    aiointercept_mock.assert_not_called()
 
 
 async def test_auth_invalid_region_brand_combo(

--- a/tests/test_oven.py
+++ b/tests/test_oven.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from whirlpool.appliancesmanager import AppliancesManager
@@ -151,7 +151,7 @@ async def test_setters(
     appliances_manager: AppliancesManager,
     auth: Auth,
     backend_selector: BackendSelector,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
     method: Callable,
     arguments: dict,
     expected_json: dict,
@@ -169,16 +169,15 @@ async def test_setters(
         "method": "POST",
         "data": None,
         "json": expected_payload["json"],
-        "allow_redirects": True,
         "headers": auth.create_headers(),
     }
 
     url = backend_selector.appliance_command_url
 
     # add call, call method
-    aioresponses_mock.post(url, payload=expected_payload)
+    aiointercept_mock.post(url, payload=expected_payload)
     assert await method(oven, **arguments)
 
     # assert args and length
-    aioresponses_mock.assert_called_with(**post_request_call_kwargs)
-    assert len(aioresponses_mock.requests[("POST", URL(url))]) == 1
+    aiointercept_mock.assert_called_with(**post_request_call_kwargs)
+    assert len(aiointercept_mock.requests[("POST", URL(url))]) == 1

--- a/tests/test_refrigerator.py
+++ b/tests/test_refrigerator.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from yarl import URL
 
 from whirlpool.appliancesmanager import AppliancesManager
@@ -45,7 +45,7 @@ async def test_setters(
     appliances_manager: AppliancesManager,
     auth: Auth,
     backend_selector: BackendSelector,
-    aioresponses_mock: aioresponses,
+    aiointercept_mock: aiointercept,
     method: Callable,
     argument: Any,
     expected_json: dict,
@@ -64,19 +64,18 @@ async def test_setters(
         "method": "POST",
         "data": None,
         "json": expected_payload["json"],
-        "allow_redirects": True,
         "headers": auth.create_headers(),
     }
 
     url = backend_selector.appliance_command_url
 
     # add call, call method
-    aioresponses_mock.post(url, payload=expected_payload)
+    aiointercept_mock.post(url, payload=expected_payload)
     await method(refrigerator, argument)
 
     # assert args and length
-    aioresponses_mock.assert_called_with(**post_request_call_kwargs)
-    assert len(aioresponses_mock.requests[("POST", URL(url))]) == 1
+    aiointercept_mock.assert_called_with(**post_request_call_kwargs)
+    assert len(aiointercept_mock.requests[("POST", URL(url))]) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
aiohttp 3.14 added a required stream_writer argument to
ClientResponse.__init__, which aioresponses monkey-patches, breaking
every mocked test. This migrates to aiointercept.
