### PR TITLE
fix: return int from KitchenTimer get_remaining_time/get_total_time

### DIFF
--- a/tests/data/mock_data.json
+++ b/tests/data/mock_data.json
@@ -1030,7 +1030,7 @@
         "updateTime": 1642158986086
       },
       "KitchenTimer01_StatusTimeRemaining": {
-        "value": "0",
+        "value": "180",
         "updateTime": 1642158986082
       },
       "Sys_AlertStatusCustomerFaultCodeNotification": {
@@ -1182,7 +1182,7 @@
         "updateTime": 1615683489232
       },
       "KitchenTimer01_SetTimeSet": {
-        "value": "0",
+        "value": "300",
         "updateTime": 1642158986082
       },
       "XCat_WifiSetRebootWifiCommModule": {
@@ -1386,7 +1386,7 @@
         "updateTime": 1592663948975
       },
       "KitchenTimer01_StatusState": {
-        "value": "0",
+        "value": "1",
         "updateTime": 1642158986082
       },
       "OvenUpperCavity_TimeStatusCycleTimeElapsed": {

--- a/tests/test_oven.py
+++ b/tests/test_oven.py
@@ -7,7 +7,7 @@ from yarl import URL
 from whirlpool.appliancesmanager import AppliancesManager
 from whirlpool.auth import Auth
 from whirlpool.backendselector import BackendSelector
-from whirlpool.oven import Cavity, CavityState, CookMode, Oven
+from whirlpool.oven import Cavity, CavityState, CookMode, KitchenTimerState, Oven
 
 
 async def test_attributes(appliances_manager: AppliancesManager):
@@ -26,6 +26,10 @@ async def test_attributes(appliances_manager: AppliancesManager):
     assert oven1.get_target_temp(Cavity.Upper) == 176.6
     assert oven1.get_cavity_state(Cavity.Upper) == CavityState.Preheating
     assert oven1.get_cook_mode(Cavity.Upper) == CookMode.Bake
+    timer1 = oven1.get_kitchen_timer()
+    assert timer1.get_total_time() == 300
+    assert timer1.get_remaining_time() == 180
+    assert timer1.get_state() == KitchenTimerState.Running
 
     oven2 = appliances_manager.ovens[1]
     assert oven2.get_online() is True
@@ -42,6 +46,10 @@ async def test_attributes(appliances_manager: AppliancesManager):
     assert oven2.get_target_temp(Cavity.Upper) is None
     assert oven2.get_cavity_state(Cavity.Upper) == CavityState.Standby
     assert oven2.get_cook_mode(Cavity.Upper) == CookMode.Standby
+    timer2 = oven2.get_kitchen_timer()
+    assert timer2.get_total_time() == 0
+    assert timer2.get_remaining_time() == 0
+    assert timer2.get_state() == KitchenTimerState.Standby
 
     oven3 = appliances_manager.ovens[2]
     assert oven3.get_online() is True

--- a/whirlpool/oven.py
+++ b/whirlpool/oven.py
@@ -147,13 +147,13 @@ class KitchenTimer:
         self._appliance = appliance
         self._attr_prefix = f"KitchenTimer{timer_id:02d}_"
 
-    def get_total_time(self):
-        return self._appliance._get_attribute(
+    def get_total_time(self) -> int | None:
+        return self._appliance._get_int_attribute(
             self._attr_prefix + ATTR_POSTFIX_KITCHEN_TIMER_SET_TIME
         )
 
-    def get_remaining_time(self):
-        return self._appliance._get_attribute(
+    def get_remaining_time(self) -> int | None:
+        return self._appliance._get_int_attribute(
             self._attr_prefix + ATTR_POSTFIX_KITCHEN_TIMER_TIME_REMAINING
         )
 


### PR DESCRIPTION
`KitchenTimer.get_remaining_time()` and `get_total_time()` called `_get_attribute()`, which returns `str | None`. Consumers doing arithmetic on the result (e.g. `timedelta(seconds=timer.get_remaining_time())`) raise `TypeError` against a real device because the value is a numeric string.

This switches both methods to `_get_int_attribute()`, matching the washer/dryer `get_time_remaining()` counterparts, and adds `int | None` return annotations.

Tests: gave SAIDOVEN1's kitchen-timer fixture attributes non-zero values (`SetTimeSet=300`, `StatusTimeRemaining=180`, `StatusState=1`) and added assertions for the int-typed returns plus `get_state()` for both a running (oven1) and standby (oven2) timer. The new assertions fail without the fix (`assert '300' == 300`) and the full suite passes with it.

Context: found while adding a kitchen-timer sensor to the Home Assistant whirlpool integration (home-assistant/core#176463).