### PR TITLE
fix(awsiot): detect dryers that report category "laundry" instead of "fabriccare"

### DIFF
--- a/tests/awsiot/test_appliancesmanager.py
+++ b/tests/awsiot/test_appliancesmanager.py
@@ -1,0 +1,20 @@
+import pytest
+
+from whirlpool.awsiot.appliancesmanager import _is_dryer_model
+
+
+@pytest.mark.parametrize(
+    ("model_number", "expected"),
+    [
+        ("MGD7020RF0", True),  # Maytag gas dryer
+        ("MED7020RF0", True),  # Maytag electric dryer
+        ("WGD5620HW1", True),  # Whirlpool gas dryer
+        ("MFW7020RF0", False),  # Maytag front-load washer
+        ("MHW6630HW0", False),  # Maytag front-load washer
+        ("WTW5010LW0", False),  # Whirlpool top-load washer
+        ("", False),
+        ("MF", False),
+    ],
+)
+def test_is_dryer_model(model_number: str, expected: bool) -> None:
+    assert _is_dryer_model(model_number) is expected

--- a/whirlpool/awsiot/appliancesmanager.py
+++ b/whirlpool/awsiot/appliancesmanager.py
@@ -24,6 +24,18 @@ from .washer import Washer
 LOGGER = logging.getLogger(__name__)
 
 
+def _is_dryer_model(model_number: str) -> bool:
+    """Whether a laundry model number denotes a dryer.
+
+    Whirlpool/Maytag/KitchenAid laundry model numbers encode the product type
+    in the third character: "D" for dryers (e.g. MGD/MED/WGD/WED) and "W" for
+    washers (e.g. MFW/MHW/WFW/WTW). Used to split the ambiguous "laundry"
+    category, since some dryers report category "laundry" instead of
+    "fabriccare".
+    """
+    return len(model_number) >= 3 and model_number[2:3].upper() == "D"
+
+
 class AppliancesManager:
     def __init__(
         self,
@@ -135,8 +147,14 @@ class AppliancesManager:
             appliance = Dryer(self._mqtt, appliance_data)
             self._dryers[appliance_data.said] = appliance
         elif appliance_data.category == "laundry":
-            appliance = Washer(self._mqtt, appliance_data)
-            self._washers[appliance_data.said] = appliance
+            # Some dryers report category "laundry" instead of "fabriccare",
+            # so disambiguate washers from dryers by model number.
+            if _is_dryer_model(appliance_data.model_number):
+                appliance = Dryer(self._mqtt, appliance_data)
+                self._dryers[appliance_data.said] = appliance
+            else:
+                appliance = Washer(self._mqtt, appliance_data)
+                self._washers[appliance_data.said] = appliance
         elif appliance_data.category == "refrigerator":
             appliance = Refrigerator(self._mqtt, appliance_data)
             self._refrigerators[appliance_data.said] = appliance


### PR DESCRIPTION
## Problem

On `aws_iot`, `AppliancesManager._add_appliance` routes `category == "laundry"` to `Washer` and expects dryers to report `fabriccare`. But some dryers report `Category: "Laundry"` (same as washers), so they get classified as washers and no `Dryer` is created.

This is the washer + dryer case from #138 (and home-assistant/core#151547): a Maytag `MGD7020RF0` dryer is discovered as `type=washer`.

## Fix

Disambiguate the `laundry` category by model number. Whirlpool/Maytag/KitchenAid laundry model numbers encode the product type in the third character (`D` = dryer, `W` = washer), so a laundry appliance whose model looks like a dryer is routed to `Dryer`. Washer behavior is unchanged.

## Evidence (redacted fixtures, per #138)

| appliance | model | `Category` | state root key |
|-----------|-------|------------|----------------|
| washer | `MFW7020RF0` | `Laundry` | `washer` |
| dryer  | `MGD7020RF0` | `Laundry` | `dryer` (was mis-typed as washer) |

## Open question

The third-character heuristic matches the models I can see (US Maytag), but you know the model scheme far better. The MQTT state also has a definitive `washer`/`dryer` root key, though it's only available after `fetch_data()`. If you'd prefer a capability- or state-based signal, I'm happy to rework — deferring to your preference.

## Testing

`ruff check` and a parametrized test for the model → type helper pass locally.

---
*Disclosure: this change was drafted with AI assistance (Claude) and reviewed by me before submitting, per this repo's `AGENTS.md` and common AI-disclosure practice.*
