### PR TITLE
Fix setter tests calling abstract base methods

### DIFF
--- a/tests/test_aircon.py
+++ b/tests/test_aircon.py
@@ -91,7 +91,7 @@ async def test_setters(
 
     # add call, call method
     aiointercept_mock.post(url, payload=expected_payload)
-    assert await method(aircon, argument)
+    assert await getattr(aircon, method.__name__)(argument)
 
     # assert args and length
     aiointercept_mock.assert_called_with(**post_request_call_kwargs)
@@ -113,6 +113,6 @@ async def test_setters_invalid_arg(
 ):
     aircon = appliances_manager.aircons[0]
     with pytest.raises(ValueError) as exc_info:
-        await method(aircon, argument)
+        await getattr(aircon, method.__name__)(argument)
 
     assert message in str(exc_info.value)

--- a/tests/test_oven.py
+++ b/tests/test_oven.py
@@ -176,7 +176,7 @@ async def test_setters(
 
     # add call, call method
     aiointercept_mock.post(url, payload=expected_payload)
-    assert await method(oven, **arguments)
+    assert await getattr(oven, method.__name__)(**arguments)
 
     # assert args and length
     aiointercept_mock.assert_called_with(**post_request_call_kwargs)

--- a/tests/test_refrigerator.py
+++ b/tests/test_refrigerator.py
@@ -71,7 +71,7 @@ async def test_setters(
 
     # add call, call method
     aiointercept_mock.post(url, payload=expected_payload)
-    await method(refrigerator, argument)
+    await getattr(refrigerator, method.__name__)(argument)
 
     # assert args and length
     aiointercept_mock.assert_called_with(**post_request_call_kwargs)
@@ -93,6 +93,6 @@ async def test_setters_invalid_arg(
 ):
     refrigerator = appliances_manager.refrigerators[0]
     with pytest.raises(ValueError) as exc_info:
-        await method(refrigerator, argument)
+        await getattr(refrigerator, method.__name__)(argument)
 
     assert message in str(exc_info.value)


### PR DESCRIPTION
The parametrized setter tests pass unbound methods from the base classes (e.g. `Oven.set_control_locked`). Since those became ABCs, `method(appliance, ...)` executes the abstract `pass` body instead of dispatching to the `httpapi` implementation, so the setter returns `None` and no request is ever made — 42 tests failing on `aws_iot` (matches the red pytest job in CI).

Fix: dispatch on the instance via `getattr(appliance, method.__name__)`. Suite goes from 78/120 to 120/120 passing.

First PR of the test refactor stack (see follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
