### PR TITLE
Stop Renovate pinning the zizmor image digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,12 @@
         "zizmorcore/zizmor-pre-commit"
       ],
       "groupName": "zizmor"
+    },
+    {
+      "description": "The zizmor image is only referenced through the action's version input, which takes a plain version rather than an image reference; the action resolves the digest itself.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/zizmorcore/zizmor"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
## Proposed change

Fixes the Renovate error reported on the dependency dashboard (#145):

```
## Errored
 - [ ] chore(deps): pin ghcr.io/zizmorcore/zizmor docker tag to 8e6b3e4
```

### Cause

Renovate's github-actions manager keeps a registry of "community actions" whose
`version:` input is extracted as a *separate* dependency (`depType: uses-with`).
`zizmorcore/zizmor-action` is one of them: its `version: 1.28.0` input is
extracted as the docker dependency `ghcr.io/zizmorcore/zizmor`, which is why the
dashboard lists it under `.github/workflows/ci.yml` even though no such image
reference appears anywhere in the repo.

`config:best-practices` enables `pinDigests`, so Renovate then tried to pin that
tag — rewriting the input as `1.28.0@sha256:8e6b3e4…` — and that update errors.

### Fix

Exclude only that dependency from digest pinning. The input takes a plain
version, and the action already resolves and pins the digest itself at runtime:

```
ghcr.io/zizmorcore/zizmor:1.28.0@sha256:8e6b3e4fb74d1aa5d23e83ea369f386c66eced0d1fb944d32cd8b2aac100b00d
```

The action ref (`zizmorcore/zizmor-action`) stays digest-pinned, and the existing
rule still groups all three zizmor updates so the action and the pre-commit hook
move together.

## Testing

- `renovate-config-validator .github/renovate.json` → "Config validated
  successfully".
- `prek --all-files` passes.

## Note

infrared-protocols will hit this same error once
[#97](https://github.com/home-assistant-libs/infrared-protocols/pull/97) merges,
since it adds the same action input and Renovate config there. Happy to send the
equivalent fix to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013apaGctByEoDP3SBAYc6f4

---
_Generated by [Claude Code](https://claude.ai/code/session_013apaGctByEoDP3SBAYc6f4)_