### PR TITLE
Add support for Whirlpool W11IOM14MS2H oven

### DIFF
--- a/whirlpool/appliancesmanager.py
+++ b/whirlpool/appliancesmanager.py
@@ -96,6 +96,7 @@ class AppliancesManager:
             "ddm_cooking_bio_self_clean_meat_probe_tourmaline_bk_v1",
             "ddm_cooking_bio_self_clean_steam_tourmaline_v2",  # <-- W9 Ovens
             "ddm_cooking_bi_mwo_self_clean_steam_tourmaline_v2",  # <-- W9 MWOs
+            "ddm_cooking_bio_std_meat_probe_indigo_v2",
         ]
 
         LOGGER.debug("Adding appliance %s", appliance_data)


### PR DESCRIPTION
Confirmed this works (entities, state, control) with my Whirlpool W11IOM14MS2H, tested via new support for ovens in the Home Assistant integration!

Resolves "Unsupported appliance data model ddm_cooking_bio_std_meat_probe_indigo_v2" message.