### PR TITLE
fix(awsiot): capability downloadUrl, nested state merge, cook timer "run" command, paho-mqtt dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "aiohttp>=3.9.1",
     "websockets>=8.1",
     "async-timeout>=4.0.3",
+    "paho-mqtt>=2.0.0",
 ]
 
 [project.readme]

--- a/tests/awsiot/mocks.py
+++ b/tests/awsiot/mocks.py
@@ -95,7 +95,14 @@ class FakeMqttClient:
             if len(parts) >= 5 and parts[0] == "cmd" and parts[3] == "request":
                 model, said, cid = parts[1], parts[2], parts[4]
                 response_topic = f"cmd/{model}/{said}/response/{cid}"
-                self.inject(response_topic, {"payload": self._getstate_reply})
+                self.inject(
+                    response_topic,
+                    {
+                        "requestId": payload.get("requestId"),
+                        "response": "accepted",
+                        "payload": self._getstate_reply,
+                    },
+                )
         # Capability download: api/capability/download/{model}/{said}
         if topic.startswith("api/capability/download/"):
             part = payload.get("capabilityPartNumber", "")

--- a/tests/awsiot/test_appliance_state.py
+++ b/tests/awsiot/test_appliance_state.py
@@ -29,6 +29,33 @@ class TestUpdateState:
             "fan": "off",
         }
 
+    def test_nested_partial_update_keeps_sibling_keys(self) -> None:
+        appliance = _make_appliance()
+        appliance.update_state(
+            {
+                "hoodLight": "off",
+                "primaryCavity": {
+                    "doorStatus": "closed",
+                    "cavityState": "idle",
+                    "cookTimer": {"time": 0, "state": "idle"},
+                },
+            }
+        )
+
+        # e.g. a cook starting: only the cavity's changed fields are pushed
+        appliance.update_state(
+            {"primaryCavity": {"cavityState": "cooking", "cookTimer": {"time": 10}}}
+        )
+
+        assert appliance.get_raw_data() == {
+            "hoodLight": "off",
+            "primaryCavity": {
+                "doorStatus": "closed",
+                "cavityState": "cooking",
+                "cookTimer": {"time": 10, "state": "idle"},
+            },
+        }
+
     def test_update_sets_initial_data_event_and_fires_callbacks(self) -> None:
         appliance = _make_appliance()
         callback = MagicMock()

--- a/tests/awsiot/test_appliance_state.py
+++ b/tests/awsiot/test_appliance_state.py
@@ -1,0 +1,40 @@
+"""Tests for AWS IoT Appliance state handling."""
+
+from unittest.mock import MagicMock
+
+from whirlpool.awsiot.appliance import Appliance
+from whirlpool.types import ApplianceInfo
+
+
+def _make_appliance() -> Appliance:
+    mqtt = MagicMock()
+    mqtt.client_id = "client"
+    info = ApplianceInfo(
+        said="SAID", name="mw", category="cooking", model_number="M", serial_number="S"
+    )
+    return Appliance(mqtt, info)
+
+
+class TestUpdateState:
+    def test_partial_update_merges_into_existing_state(self) -> None:
+        appliance = _make_appliance()
+        appliance.update_state({"door": "closed", "hoodLight": "off", "fan": "off"})
+
+        # dt/.../state/update messages only carry the changed attributes
+        appliance.update_state({"hoodLight": "low"})
+
+        assert appliance.get_raw_data() == {
+            "door": "closed",
+            "hoodLight": "low",
+            "fan": "off",
+        }
+
+    def test_update_sets_initial_data_event_and_fires_callbacks(self) -> None:
+        appliance = _make_appliance()
+        callback = MagicMock()
+        appliance.register_attr_callback(callback)
+
+        appliance.update_state({"door": "open"})
+
+        assert appliance._initial_data_event.is_set()
+        callback.assert_called_once()

--- a/tests/test_awsiot_capabilities.py
+++ b/tests/test_awsiot_capabilities.py
@@ -15,6 +15,7 @@ from aiointercept import aiointercept
 from whirlpool.awsiot.capabilities import (
     CapabilityDownloader,
     CapabilityDownloadError,
+    OptionRange,
     has_microwave_cavity,
     parse_microwave_capability_profile,
 )
@@ -77,6 +78,43 @@ class TestParseMicrowaveCapability:
         assert not profile.supports_hood_fan
         assert not profile.supports_quiet_mode
         assert not profile.supports_sabbath_mode
+
+    def test_recipe_options_parsed_from_real_file(self) -> None:
+        profile = parse_microwave_capability_profile(_load("capability_mwo.json"))
+        recipes = profile.recipes
+
+        microwave = recipes["microwave"]
+        assert microwave.power_level == OptionRange(
+            min=10, max=100, step=10, default=100
+        )
+        assert microwave.fixed_power_level is None
+        assert microwave.cook_time == OptionRange(min=5, max=5940, step=1, default=5)
+
+        reheat = recipes["reheat"]
+        assert reheat.power_level is None
+        assert reheat.fixed_power_level == 70
+        assert reheat.cook_time.default == 30
+
+        keep_warm = recipes["keepWarm"]
+        assert keep_warm.cook_time == OptionRange(
+            min=900, max=3600, step=900, default=1800
+        )
+
+        # Sensor/auto recipes keyed on amount/weight are not timed recipes.
+        assert "soupReheat" not in recipes
+        assert "meatDefrost" not in recipes
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(10, True), (100, True), (50, True), (55, False), (0, False), (110, False)],
+    )
+    def test_option_range_contains_respects_step(
+        self, value: int, expected: bool
+    ) -> None:
+        assert (
+            OptionRange(min=10, max=100, step=10, default=100).contains(value)
+            is expected
+        )
 
     def test_profile_equality_is_value_based(self) -> None:
         raw = _load("capability_mwo.json")
@@ -297,6 +335,34 @@ class TestDownloaderFetchBody:
         with pytest.raises(CapabilityDownloadError):
             await asyncio.gather(respond(), downloader.get(SAID, MODEL, PART))
 
+    async def test_non_200_response_code_is_download_error(
+        self,
+        http_session: aiohttp.ClientSession,
+        aio_mock: aiointercept,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "whirlpool.awsiot.capabilities.CAPABILITY_DOWNLOAD_TIMEOUT", 1.0
+        )
+        monkeypatch.setattr(
+            "whirlpool.awsiot.capabilities.CAPABILITY_DOWNLOAD_RETRIES", 1
+        )
+        mqtt = FakeMqttClient()
+        downloader = CapabilityDownloader(mqtt, http_session)
+        aio_mock.get(CAP_URL, body=json.dumps(FIXTURE_JSON))
+
+        async def respond() -> None:
+            for _ in range(50):
+                if mqtt.published:
+                    break
+                await asyncio.sleep(0)
+            downloader.handle_message(
+                RESP_TOPIC, {"responseCode": 404, "downloadUrl": CAP_URL}
+            )
+
+        with pytest.raises(CapabilityDownloadError, match="responseCode 404"):
+            await asyncio.gather(respond(), downloader.get(SAID, MODEL, PART))
+
     async def test_document_without_part_number_is_download_error(
         self, http_session: aiohttp.ClientSession, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -355,7 +421,5 @@ class TestDownloaderFetchBody:
                 await asyncio.sleep(0)
             downloader.handle_message(RESP_TOPIC, FIXTURE_JSON)
 
-        _, raw = await asyncio.gather(
-            respond(), downloader.get(SAID, MODEL, PART)
-        )
+        _, raw = await asyncio.gather(respond(), downloader.get(SAID, MODEL, PART))
         assert raw["partNumber"] == PART

--- a/tests/test_awsiot_capabilities.py
+++ b/tests/test_awsiot_capabilities.py
@@ -111,6 +111,8 @@ PART = "W1111"
 REQ_TOPIC = f"api/capability/download/{MODEL}/{SAID}"
 RESP_TOPIC = f"{REQ_TOPIC}/response"
 CAP_URL = "https://caps.example.com/profile.json"
+# Shape of the broker's reply on api/capability/download/.../response
+CAP_RESPONSE = {"responseCode": 200, "downloadUrl": CAP_URL}
 FIXTURE_JSON = {
     "partNumber": PART,
     "appliance": {"features": {"microwaveOven": {}}},
@@ -177,7 +179,7 @@ class TestHandleMessageDispatch:
                 if mqtt.published:
                     break
                 await asyncio.sleep(0)
-            consumed = downloader.handle_message(RESP_TOPIC, {"url": CAP_URL})
+            consumed = downloader.handle_message(RESP_TOPIC, CAP_RESPONSE)
             assert consumed is True
 
         _, raw = await asyncio.gather(
@@ -213,7 +215,7 @@ class TestDownloaderCache:
                 if mqtt.published:
                     break
                 await asyncio.sleep(0)
-            downloader.handle_message(RESP_TOPIC, {"url": CAP_URL})
+            downloader.handle_message(RESP_TOPIC, CAP_RESPONSE)
 
         _, first = await asyncio.gather(
             respond_once(), downloader.get(SAID, MODEL, PART)
@@ -244,7 +246,7 @@ class TestDownloaderRetry:
         async def respond_on_third() -> None:
             while len(mqtt.published) < 3:
                 await asyncio.sleep(0.01)
-            downloader.handle_message(RESP_TOPIC, {"url": CAP_URL})
+            downloader.handle_message(RESP_TOPIC, CAP_RESPONSE)
 
         _, raw = await asyncio.gather(
             respond_on_third(), downloader.get(SAID, MODEL, PART)
@@ -290,7 +292,7 @@ class TestDownloaderFetchBody:
                 if mqtt.published:
                     break
                 await asyncio.sleep(0)
-            downloader.handle_message(RESP_TOPIC, {"url": CAP_URL})
+            downloader.handle_message(RESP_TOPIC, CAP_RESPONSE)
 
         with pytest.raises(CapabilityDownloadError):
             await asyncio.gather(respond(), downloader.get(SAID, MODEL, PART))

--- a/tests/test_microwave.py
+++ b/tests/test_microwave.py
@@ -582,7 +582,7 @@ async def test_start_cook_publishes_expected_payload(
     mwo = manager.microwaves[0]
 
     before = len(fake_mqtt.published)
-    ok = await mwo.set_cook(Recipe.Microwave, 50, 30)
+    ok = await mwo.set_cook(Recipe.Microwave, 30, power_level=50)
     assert ok is True
 
     assert len(fake_mqtt.published) == before + 1
@@ -610,13 +610,14 @@ async def test_start_cook_returns_false_when_remote_start_disabled(
     )
 
     before = len(fake_mqtt.published)
-    ok = await mwo.set_cook(Recipe.Reheat, 100, 60)
+    ok = await mwo.set_cook(Recipe.Reheat, 60)
     assert ok is False
     assert len(fake_mqtt.published) == before  # nothing published
 
 
-@pytest.mark.parametrize("power_level", [0, -1, 101, 200])
-async def test_start_cook_rejects_invalid_power_level(
+# capability_mwo.json: microwave.mwoPowerLevel range is 10..100 step 10
+@pytest.mark.parametrize("power_level", [0, -1, 5, 55, 101, 200])
+async def test_start_cook_rejects_power_level_outside_capability_range(
     aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
     power_level: int,
 ) -> None:
@@ -624,12 +625,24 @@ async def test_start_cook_rejects_invalid_power_level(
     mwo = manager.microwaves[0]
     before = len(fake_mqtt.published)
     with pytest.raises(ValueError):
-        await mwo.set_cook(Recipe.Microwave, power_level, 30)
+        await mwo.set_cook(Recipe.Microwave, 30, power_level=power_level)
     assert len(fake_mqtt.published) == before
 
 
-@pytest.mark.parametrize("duration", [0, -5])
-async def test_start_cook_rejects_invalid_duration(
+async def test_start_cook_requires_power_level_for_editable_recipe(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+    before = len(fake_mqtt.published)
+    with pytest.raises(ValueError):
+        await mwo.set_cook(Recipe.Microwave, 30)
+    assert len(fake_mqtt.published) == before
+
+
+# capability_mwo.json: cookTime range is 5..5940 step 1
+@pytest.mark.parametrize("duration", [0, -5, 4, 5941])
+async def test_start_cook_rejects_duration_outside_capability_range(
     aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
     duration: int,
 ) -> None:
@@ -637,8 +650,62 @@ async def test_start_cook_rejects_invalid_duration(
     mwo = manager.microwaves[0]
     before = len(fake_mqtt.published)
     with pytest.raises(ValueError):
-        await mwo.set_cook(Recipe.Microwave, 50, duration)
+        await mwo.set_cook(Recipe.Microwave, duration, power_level=50)
     assert len(fake_mqtt.published) == before
+
+
+@pytest.mark.parametrize(
+    "recipe,fixed_power",
+    [(Recipe.Reheat, 70), (Recipe.Defrost, 20), (Recipe.Soften, 20)],
+)
+async def test_start_cook_fixed_power_recipes_omit_power_level(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+    recipe: Recipe,
+    fixed_power: int,
+) -> None:
+    """Recipes with mwoPowerLevel under nonEditableOptions must not send it."""
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+
+    options = mwo.get_recipe_options(recipe)
+    assert options is not None
+    assert options.power_level is None
+    assert options.fixed_power_level == fixed_power
+
+    ok = await mwo.set_cook(recipe, 60)
+    assert ok is True
+    body = fake_mqtt.published[-1][1]["payload"]
+    assert body["recipeID"] == recipe.value
+    assert "mwoPowerLevel" not in body
+    assert body["cookTimer"] == {"command": "run", "time": 60}
+
+
+async def test_start_cook_rejects_power_level_for_fixed_power_recipe(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+    before = len(fake_mqtt.published)
+    with pytest.raises(ValueError, match="fixed power level of 70"):
+        await mwo.set_cook(Recipe.Reheat, 60, power_level=100)
+    assert len(fake_mqtt.published) == before
+
+
+async def test_command_acks_and_rejections_do_not_touch_state(
+    aws_manager: tuple[AwsAppliancesManager, FakeMqttClient],
+) -> None:
+    manager, fake_mqtt = aws_manager
+    mwo = manager.microwaves[0]
+    before = mwo.get_raw_data()
+    topic = f"cmd/{MWO_MODEL}/{MWO_SAID}/response/{fake_mqtt.client_id}"
+
+    fake_mqtt.inject(topic, {"requestId": "1", "response": "accepted"})
+    fake_mqtt.inject(
+        topic,
+        {"requestId": "2", "response": "rejected", "payload": {"errorCode": "C000"}},
+    )
+
+    assert mwo.get_raw_data() == before
 
 
 async def test_cancel_cook_publishes_expected_payload(
@@ -674,6 +741,9 @@ async def test_start_cook_recipe_enum_wire_value(
 ) -> None:
     manager, fake_mqtt = aws_manager
     mwo = manager.microwaves[0]
-    await mwo.set_cook(recipe, 50, 30)
+    if recipe is Recipe.Microwave:
+        await mwo.set_cook(recipe, 30, power_level=50)
+    else:
+        await mwo.set_cook(recipe, 30)
     _, payload = fake_mqtt.published[-1]
     assert payload["payload"]["recipeID"] == wire_value

--- a/tests/test_microwave.py
+++ b/tests/test_microwave.py
@@ -594,7 +594,7 @@ async def test_start_cook_publishes_expected_payload(
     assert body["recipeID"] == "microwave"
     assert body["mwoPowerLevel"] == 50.0
     assert isinstance(body["mwoPowerLevel"], float)
-    assert body["cookTimer"] == {"command": "start", "time": 30}
+    assert body["cookTimer"] == {"command": "run", "time": 30}
 
 
 async def test_start_cook_returns_false_when_remote_start_disabled(

--- a/whirlpool/awsiot/appliance.py
+++ b/whirlpool/awsiot/appliance.py
@@ -28,6 +28,18 @@ def gated_set(support_check, label):
     return decorator
 
 
+def _deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `base` with `update` merged in, recursing into dicts."""
+    merged = dict(base)
+    for key, value in update.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 class Appliance(BaseAppliance):
     """Whirlpool awsiot appliance class"""
 
@@ -72,7 +84,7 @@ class Appliance(BaseAppliance):
         so replacing the dict would drop everything else until the next
         getState round-trip.
         """
-        self._data_dict = {**self._data_dict, **new_state}
+        self._data_dict = _deep_merge(self._data_dict, new_state)
         self._initial_data_event.set()
         for callback in self._attr_changed:
             callback()

--- a/whirlpool/awsiot/appliance.py
+++ b/whirlpool/awsiot/appliance.py
@@ -66,8 +66,13 @@ class Appliance(BaseAppliance):
         )
 
     def update_state(self, new_state: dict[str, Any]):
-        """Update appliance state and call callbacks."""
-        self._data_dict = new_state
+        """Merge a (possibly partial) state update and call callbacks.
+
+        `dt/.../state/update` messages only carry the attributes that changed,
+        so replacing the dict would drop everything else until the next
+        getState round-trip.
+        """
+        self._data_dict = {**self._data_dict, **new_state}
         self._initial_data_event.set()
         for callback in self._attr_changed:
             callback()

--- a/whirlpool/awsiot/appliancesmanager.py
+++ b/whirlpool/awsiot/appliancesmanager.py
@@ -121,7 +121,7 @@ class AppliancesManager:
         thing_attrs = thing.get("attributes", {})
         try:
             name = bytes.fromhex(thing_attrs.get("Name", "")).decode("utf-8")
-        except (ValueError, UnicodeDecodeError):
+        except ValueError, UnicodeDecodeError:
             name = thing["thingName"]
 
         appliance_data = ApplianceInfo(
@@ -211,7 +211,14 @@ class AppliancesManager:
         said = parts[2]
 
         if topic.startswith("cmd/") and "response" in topic:
-            state = payload.get("payload", {})
+            # Only a getState response carries the state; plain command acks
+            # ({"response": "accepted"}) and rejections ({"errorCode": ...})
+            # must not be merged into the appliance state.
+            if payload.get("response") != "accepted":
+                return
+            state = payload.get("payload")
+            if not isinstance(state, dict) or not state:
+                return
         elif topic.startswith("dt/") and "state/update" in topic:
             state = payload
         else:

--- a/whirlpool/awsiot/capabilities.py
+++ b/whirlpool/awsiot/capabilities.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import aiohttp
@@ -31,6 +31,35 @@ class CapabilityDownloadError(Exception):
 
 
 @dataclass(frozen=True)
+class OptionRange:
+    """Inclusive numeric range with a step, as declared under whrOptions."""
+
+    min: int
+    max: int
+    step: int
+    default: int
+
+    def contains(self, value: int) -> bool:
+        if not self.min <= value <= self.max:
+            return False
+        return self.step <= 1 or (value - self.min) % self.step == 0
+
+
+@dataclass(frozen=True)
+class MicrowaveRecipeOptions:
+    """Editable options of one cavity recipe (e.g. "microwave", "reheat").
+
+    `power_level` is the editable mwoPowerLevel range, or None when the recipe
+    has a fixed power level (listed under nonEditableOptions) that must not be
+    sent. `cook_time` is the editable cookTime range in seconds.
+    """
+
+    cook_time: OptionRange
+    power_level: OptionRange | None = None
+    fixed_power_level: int | None = None
+
+
+@dataclass(frozen=True)
 class MicrowaveCapabilityProfile:
     """The capability switches the Microwave class currently uses."""
 
@@ -41,6 +70,7 @@ class MicrowaveCapabilityProfile:
     supports_quiet_mode: bool
     supports_control_lock: bool
     supports_sabbath_mode: bool
+    recipes: dict[str, MicrowaveRecipeOptions] = field(default_factory=dict)
 
 
 def _read_part_number(raw: dict[str, Any]) -> str:
@@ -64,9 +94,64 @@ def _cavity_metas(raw: dict[str, Any]) -> list[dict[str, Any]]:
 
 def has_microwave_cavity(raw: dict[str, Any]) -> bool:
     """Whether the capability file declares a microwave oven cavity."""
-    return any(
-        meta.get("cavityType") == "microwaveOven" for meta in _cavity_metas(raw)
+    return any(meta.get("cavityType") == "microwaveOven" for meta in _cavity_metas(raw))
+
+
+def _option_range(option: Any) -> OptionRange | None:
+    if not isinstance(option, dict):
+        return None
+    rng = option.get("range")
+    if not isinstance(rng, dict):
+        return None
+    try:
+        return OptionRange(
+            min=int(rng["min"]),
+            max=int(rng["max"]),
+            step=int(rng.get("step", 1)),
+            default=int(rng.get("default", rng["min"])),
+        )
+    except KeyError, TypeError, ValueError:
+        return None
+
+
+def _parse_recipe_options(recipe: Any) -> MicrowaveRecipeOptions | None:
+    if not isinstance(recipe, dict):
+        return None
+    options = recipe.get("whrOptions")
+    if not isinstance(options, dict):
+        return None
+    required = options.get("requiredOptions")
+    required = required if isinstance(required, dict) else {}
+    non_editable = options.get("nonEditableOptions")
+    non_editable = non_editable if isinstance(non_editable, dict) else {}
+
+    cook_time = _option_range(required.get("cookTime"))
+    if cook_time is None:
+        # Not a timed recipe (e.g. sensor/auto recipes keyed on amount/weight).
+        return None
+
+    fixed_power = non_editable.get("mwoPowerLevel")
+    return MicrowaveRecipeOptions(
+        cook_time=cook_time,
+        power_level=_option_range(required.get("mwoPowerLevel")),
+        fixed_power_level=fixed_power if isinstance(fixed_power, int) else None,
     )
+
+
+def _parse_recipes(raw: dict[str, Any]) -> dict[str, MicrowaveRecipeOptions]:
+    """Collect the timed recipes of the microwave cavity, keyed by wire name."""
+    recipes: dict[str, MicrowaveRecipeOptions] = {}
+    for meta in _cavity_metas(raw):
+        if meta.get("cavityType") != "microwaveOven":
+            continue
+        declared = meta.get("recipes")
+        if not isinstance(declared, dict):
+            continue
+        for name, recipe in declared.items():
+            parsed = _parse_recipe_options(recipe)
+            if parsed is not None:
+                recipes[name] = parsed
+    return recipes
 
 
 def parse_microwave_capability_profile(
@@ -85,6 +170,7 @@ def parse_microwave_capability_profile(
         supports_quiet_mode=raw.get("quietMode") is True,
         supports_control_lock=raw.get("supportsHmiControlLockout") is True,
         supports_sabbath_mode=supports_sabbath_mode,
+        recipes=_parse_recipes(raw),
     )
 
 
@@ -129,9 +215,7 @@ class CapabilityDownloader:
         last_err: Exception | None = None
         for attempt in range(CAPABILITY_DOWNLOAD_RETRIES):
             try:
-                raw = await self._download(
-                    said, model_number, capability_part_number
-                )
+                raw = await self._download(said, model_number, capability_part_number)
                 self._cache[capability_part_number] = raw
                 return raw
             except (TimeoutError, CapabilityDownloadError) as e:
@@ -179,6 +263,12 @@ class CapabilityDownloader:
                     f"Timed out waiting for capability response for {said}"
                 ) from e
 
+            response_code = response.get("responseCode")
+            if response_code is not None and response_code != 200:
+                raise CapabilityDownloadError(
+                    f"Capability request for {said} returned "
+                    f"responseCode {response_code}"
+                )
             raw = await self._download_file(response)
             _read_part_number(raw)  # sanity-check before caching
             return raw
@@ -188,7 +278,7 @@ class CapabilityDownloader:
 
     async def _download_file(self, mqtt_response: dict[str, Any]) -> dict[str, Any]:
         # The broker replies with {"responseCode": 200, "downloadUrl": "..."}.
-        url = mqtt_response.get("downloadUrl") or mqtt_response.get("url")
+        url = mqtt_response.get("downloadUrl")
         if not isinstance(url, str) or not url.startswith("http"):
             return mqtt_response
         async with self._session.get(url) as resp:

--- a/whirlpool/awsiot/capabilities.py
+++ b/whirlpool/awsiot/capabilities.py
@@ -187,7 +187,8 @@ class CapabilityDownloader:
             self._mqtt.unsubscribe(response_topic)
 
     async def _download_file(self, mqtt_response: dict[str, Any]) -> dict[str, Any]:
-        url = mqtt_response.get("url")
+        # The broker replies with {"responseCode": 200, "downloadUrl": "..."}.
+        url = mqtt_response.get("downloadUrl") or mqtt_response.get("url")
         if not isinstance(url, str) or not url.startswith("http"):
             return mqtt_response
         async with self._session.get(url) as resp:

--- a/whirlpool/awsiot/microwave.py
+++ b/whirlpool/awsiot/microwave.py
@@ -263,7 +263,10 @@ class Microwave(MicrowaveABC, Appliance):
                 "addressee": "primaryCavity",
                 "recipeID": recipe.value,
                 "mwoPowerLevel": float(power_level),
-                "cookTimer": {"command": "start", "time": duration_seconds},
+                # Timer commands are run/set/add (no "start"); the app uses
+                # "run" when starting a recipe. An unknown command is ignored
+                # and the recipe falls back to its default cookTime (5 s).
+                "cookTimer": {"command": "run", "time": duration_seconds},
             },
         )
         return True

--- a/whirlpool/awsiot/microwave.py
+++ b/whirlpool/awsiot/microwave.py
@@ -1,7 +1,7 @@
 """Concrete awsiot Microwave — translates MQTT state to the Microwave ABC."""
 
 import logging
-from typing import override
+from typing import Any, override
 
 from ..microwave import (
     HoodFanSpeed,
@@ -16,7 +16,7 @@ from ..microwave import (
 )
 from ..types import ApplianceInfo
 from .appliance import Appliance, gated_set
-from .capabilities import MicrowaveCapabilityProfile
+from .capabilities import MicrowaveCapabilityProfile, MicrowaveRecipeOptions
 from .mqttclient import MqttClient
 
 LOGGER = logging.getLogger(__name__)
@@ -92,9 +92,7 @@ class Microwave(MicrowaveABC, Appliance):
 
     @override
     async def set_cavity_light(self, on: bool) -> bool:
-        self._send_command(
-            "set", {"addressee": "primaryCavity", "cavityLight": on}
-        )
+        self._send_command("set", {"addressee": "primaryCavity", "cavityLight": on})
         return True
 
     @override
@@ -217,9 +215,7 @@ class Microwave(MicrowaveABC, Appliance):
     @override
     @gated_set(supports_hood_light_color, "hood light color control")
     async def set_hood_light_color(self, color: HoodLightColor) -> bool:
-        self._send_command(
-            "set", {"addressee": "hoodLightColor", "value": color.value}
-        )
+        self._send_command("set", {"addressee": "hoodLightColor", "value": color.value})
         return True
 
     @override
@@ -240,35 +236,58 @@ class Microwave(MicrowaveABC, Appliance):
         self._send_command("set", {"addressee": "sabbathMode", "value": on})
         return True
 
+    def get_recipe_options(self, recipe: Recipe) -> MicrowaveRecipeOptions | None:
+        """Editable ranges for `recipe` on this model, or None if unsupported."""
+        return self.capability_profile.recipes.get(recipe.value)
+
     @override
     async def set_cook(
         self,
         recipe: Recipe,
-        power_level: int,
         duration_seconds: int,
+        power_level: int | None = None,
     ) -> bool:
-        if not 1 <= power_level <= 100:
-            raise ValueError("power_level must be between 1 and 100")
-        if duration_seconds < 1:
-            raise ValueError("duration_seconds must be >= 1")
+        options = self.get_recipe_options(recipe)
+        if options is None:
+            raise ValueError(f"recipe {recipe.value!r} is not supported by {self.said}")
+
+        cook_time = options.cook_time
+        if not cook_time.contains(duration_seconds):
+            raise ValueError(
+                f"duration_seconds must be {cook_time.min}-{cook_time.max} s "
+                f"in steps of {cook_time.step} for recipe {recipe.value!r}"
+            )
+
+        payload: dict[str, Any] = {
+            "addressee": "primaryCavity",
+            "recipeID": recipe.value,
+            "cookTimer": {"command": "run", "time": duration_seconds},
+        }
+        if options.power_level is not None:
+            if power_level is None:
+                raise ValueError(f"recipe {recipe.value!r} requires power_level")
+            if not options.power_level.contains(power_level):
+                raise ValueError(
+                    f"power_level must be {options.power_level.min}-"
+                    f"{options.power_level.max} in steps of "
+                    f"{options.power_level.step} for recipe {recipe.value!r}"
+                )
+            payload["mwoPowerLevel"] = float(power_level)
+        elif power_level is not None:
+            fixed = options.fixed_power_level
+            raise ValueError(
+                f"recipe {recipe.value!r} has a fixed power level"
+                + (f" of {fixed}" if fixed is not None else "")
+                + "; omit power_level"
+            )
+
         if not self.get_remote_start_enabled():
             LOGGER.warning(
                 "Remote start not enabled on %s — enable on the physical panel",
                 self.said,
             )
             return False
-        self._send_command(
-            "run",
-            {
-                "addressee": "primaryCavity",
-                "recipeID": recipe.value,
-                "mwoPowerLevel": float(power_level),
-                # Timer commands are run/set/add (no "start"); the app uses
-                # "run" when starting a recipe. An unknown command is ignored
-                # and the recipe falls back to its default cookTime (5 s).
-                "cookTimer": {"command": "run", "time": duration_seconds},
-            },
-        )
+        self._send_command("run", payload)
         return True
 
     @override

--- a/whirlpool/microwave.py
+++ b/whirlpool/microwave.py
@@ -84,9 +84,15 @@ class Microwave(Appliance, ABC):
     async def set_cook(
         self,
         recipe: Recipe,
-        power_level: int,
         duration_seconds: int,
-    ) -> bool: ...
+        power_level: int | None = None,
+    ) -> bool:
+        """Start `recipe` for `duration_seconds`.
+
+        `power_level` (percent) is required for recipes with an editable power
+        level (e.g. Microwave) and must be omitted for recipes whose power is
+        fixed by the appliance (e.g. Reheat, Defrost, Soften).
+        """
 
     @abstractmethod
     async def stop_cook(self) -> bool: ...


### PR DESCRIPTION
Found while live-testing #160 against a KitchenAid KMML550RPS00 microwave. None of these are in the CLI PR itself; they're all in `aws_iot` library code, but the first one blocks the CLI from listing anything at all and the third means `start_cook` never honoured its duration.

### 1. Capability download parses the wrong key (blocker)
The broker's reply on `api/capability/download/<model>/<said>/response` is
```json
{"responseCode": 200, "downloadUrl": "https://iot-evolution-cooking-category.s3.amazonaws.com/PROD/Appliance/<part>?X-Amz-..."}
```
`CapabilityDownloader._download_file` looked for `"url"`, so the MQTT envelope itself was handed to `_read_part_number` and every appliance failed with `Capability file missing 'partNumber' — skipping`. Fixed to read `downloadUrl` (with `url` kept as a fallback); tests updated to use the real response shape.

### 2. `Appliance.update_state` replaced the dict with partial deltas
`dt/<model>/<said>/state/update` only carries what changed, and the deltas are nested partials. Captured while a cook started:
```json
{"primaryCavity": {"mwoPowerLevel": 30}}
{"primaryCavity": {"recipeId": "microwave"}}
{"primaryCavity": {"cavityState": "cooking", "turnTable": "on", "cookTimer": {"time": 20}}}
{"primaryCavity": {"recipeExecutionState": "RUNNING"}}
{"primaryCavity": {"cavityLight": true, "cookTimer": {"state": "running", "timeComplete": 1787702389}, "sessionId": "..."}}
```
Replacing the dict (or even shallow-merging it) dropped door/recipe/fan/etc. to `None` after any setter until the next `getState`. Now merges recursively. Added `tests/awsiot/test_appliance_state.py`.

### 3. `start_cook` sent `cookTimer.command: "start"` — duration was ignored
Every cook ran for exactly 5 s regardless of `duration_seconds` (the recipe's capability-file default: `cookTime.range.default = 5`). The appliance's timer commands are **`run` / `set` / `add`** — there is no `start` — and an unknown command is silently ignored (the `run` itself is still `accepted`). From the KitchenAid app decompile: `RecipeCommand.getCommandJSONString` serialises `cookTimer: {command, time}` and the start-cycle path picks `command = "run"` (`vk.b` enum → `Constants.Commands.COMMAND_RUN`; `set` is used to modify a running timer, `add` for add-time). Verified live: requested 20 s → `cookTimer.time: 20`, `running` → `completed` in 20.0 s. Tried and rejected along the way: top-level `cookTime` (rejected `C000`), `time` as float (still 5 s).

### 4. `set_cook` validation didn't match the capability file (review follow-up)
`power_level` was checked 1..100 and `duration_seconds` >= 1, but the recipe's `whrOptions` say otherwise (`microwave.mwoPowerLevel` 10100 step 10; `cookTime` min 5; `keepWarm` 9003600 step 900), and only `microwave` has an editable power level  `reheat`/`defrost`/`soften` fix it under `nonEditableOptions`. The profile now carries `recipes[name] -> MicrowaveRecipeOptions` and `set_cook(recipe, duration_seconds, power_level=None)` validates against it, sending `mwoPowerLevel` only when editable. Command acks/rejections on `cmd/.../response` are no longer merged into state.

### 5. `paho-mqtt` missing from `pyproject.toml`
It was only in `requirements.txt`, so `pip install -e .` followed by `import whirlpool` raised `ModuleNotFoundError: paho`.

### Verified live
With these applied, `cli.py -l` lists the microwave and the #160 menu works end to end: status, cavity light on/off, hood fan Low/Off, hood light Low/Off, raw dump, and `t` (Microwave recipe, power 30, 20 s) running for the full 20 s then `o` cancel. State stayed coherent through every push. `pytest`: 154 passed; `ruff check` and `basedpyright` clean.

Side observations, not addressed here: `cookTimer.timeComplete` is an epoch timestamp (the CLI prints it as "time complete (seconds)"); `ovenDisplayTemperature: 25` with `temperatureUnit: fahrenheit` looks like °C; after a cook completes the recipe sits in step 1 (the "addTime" user prompt) with `recipeExecutionState: RUNNING` until cancelled, and a new `run` while there is rejected `C103`; the app sends `turntable` (lowercase) as a boolean in commands while state reports `turnTable: "on"/"off"`.

Note: `ruff format --check` reports pre-existing drift in 9 files unrelated to this change (newer ruff than the pinned hook) — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK2q3npAU3S4xhta4QD8YN