### PR TITLE
fix(awsiot): parenthesize multi-exception except clauses

### DIFF
--- a/whirlpool/awsiot/capabilities.py
+++ b/whirlpool/awsiot/capabilities.py
@@ -110,7 +110,7 @@ def _option_range(option: Any) -> OptionRange | None:
             step=int(rng.get("step", 1)),
             default=int(rng.get("default", rng["min"])),
         )
-    except KeyError, TypeError, ValueError:
+    except (KeyError, TypeError, ValueError):
         return None
 
 


### PR DESCRIPTION
## What

The AWS IoT backend shipped in #162 contained two Python 2-style `except A, B:` clauses (in `whirlpool/awsiot/appliancesmanager.py` and `whirlpool/awsiot/capabilities.py`), which are a `SyntaxError` under Python 3 and make the entire `whirlpool.awsiot` module unimportable.

## Why

Any import of the newer backend fails at parse time — washer, dryer, and microwave code alike.

## Change

- `except (ValueError, UnicodeDecodeError):`
- `except (KeyError, TypeError, ValueError):`

## Note

`ruff format` (0.16.5) currently wants to strip these parentheses and regenerate the invalid form, so `ruff format --check` will flag these two lines. Recommend pinning/upgrading ruff before merging.
