### PR TITLE
Implement aws api washer and dryer

### DIFF
--- a/tests/awsiot/test_appliancesmanager.py
+++ b/tests/awsiot/test_appliancesmanager.py
@@ -1,0 +1,94 @@
+"""Tests for AWS IoT appliance routing in AppliancesManager."""
+
+import json
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import pytest
+import pytest_asyncio
+from aiointercept import aiointercept
+
+from tests.awsiot.mocks import (
+    make_mqtt_factory,
+    mock_aws_http_api,
+    patch_aws_manager_mqtt,
+)
+from whirlpool.auth import Auth
+from whirlpool.awsiot.appliancesmanager import AppliancesManager as AwsAppliancesManager
+from whirlpool.awsiot.appliancesmanager import _is_dryer_model
+from whirlpool.awsiot.dryer import Dryer
+from whirlpool.awsiot.washer import Washer
+from whirlpool.backendselector import BackendSelector
+
+_DATA_DIR = Path(__file__).parent.parent / "data" / "awsiot"
+
+WASHER_THING = json.loads((_DATA_DIR / "washer_thing.json").read_text())
+DRYER_THING = json.loads((_DATA_DIR / "dryer_thing.json").read_text())
+WASHER_STATE = json.loads((_DATA_DIR / "washer_state.json").read_text())
+
+WASHER_CAP_PART = "W11723751"
+DRYER_CAP_PART = "W11729930"
+
+
+@pytest.mark.parametrize(
+    ("model_number", "expected"),
+    [
+        ("MGD7020RF0", True),  # Maytag gas dryer
+        ("MED7020RF0", True),  # Maytag electric dryer
+        ("WGD5620HW1", True),  # Whirlpool gas dryer
+        ("MFW7020RF0", False),  # Maytag front-load washer
+        ("MHW6630HW0", False),  # Maytag front-load washer
+        ("WTW5010LW0", False),  # Whirlpool top-load washer
+        ("", False),
+        ("MF", False),
+    ],
+)
+def test_is_dryer_model(model_number: str, expected: bool) -> None:
+    assert _is_dryer_model(model_number) is expected
+
+
+@pytest_asyncio.fixture
+async def laundry_manager(
+    auth: Auth,
+    backend_selector: BackendSelector,
+    client_session_fixture: aiohttp.ClientSession,
+    aiointercept_mock: aiointercept,
+) -> AsyncGenerator[AwsAppliancesManager]:
+    """An AwsAppliancesManager connected to a washer + dryer thing."""
+
+    mock_aws_http_api(aiointercept_mock, backend_selector, [WASHER_THING, DRYER_THING])
+    capability_replies: dict[str, dict[str, Any] | None] = {
+        WASHER_CAP_PART: {"partNumber": WASHER_CAP_PART},
+        DRYER_CAP_PART: {"partNumber": DRYER_CAP_PART},
+    }
+    mqtt_factory = make_mqtt_factory(WASHER_STATE, capability_replies)
+    with patch_aws_manager_mqtt(mqtt_factory):
+        manager = AwsAppliancesManager(auth, client_session_fixture, lambda: None)
+        ok = await manager.connect()
+        assert ok is True
+        yield manager
+
+
+async def test_laundry_category_is_split_into_washer_and_dryer(
+    laundry_manager: AwsAppliancesManager,
+) -> None:
+    assert len(laundry_manager.washers) == 1
+    assert len(laundry_manager.dryers) == 1
+
+    washer = laundry_manager.washers[0]
+    dryer = laundry_manager.dryers[0]
+
+    assert isinstance(washer, Washer)
+    assert isinstance(dryer, Dryer)
+    assert washer.said == "WPR1W00000001"
+    assert dryer.said == "WPR1D00000002"
+
+
+async def test_laundry_fixtures_surface_standby_state(
+    laundry_manager: AwsAppliancesManager,
+) -> None:
+    washer = laundry_manager.washers[0]
+    assert washer.get_machine_state() is not None
+    assert washer.get_time_remaining() == 5351

--- a/tests/awsiot/test_dryer.py
+++ b/tests/awsiot/test_dryer.py
@@ -40,6 +40,10 @@ def test_time_remaining() -> None:
     assert _make_dryer().get_time_remaining() == 2185
 
 
+def test_cycle_time_complete() -> None:
+    assert _make_dryer().get_cycle_time_complete() == 1783895096
+
+
 def test_drum_light_off() -> None:
     assert _make_dryer().get_drum_light_on() is False
 

--- a/tests/awsiot/test_dryer.py
+++ b/tests/awsiot/test_dryer.py
@@ -72,7 +72,13 @@ def test_dryness_decodes_known_level() -> None:
 def test_running_cycle_reports_phase_and_state() -> None:
     dryer = _make_dryer()
     dryer.update_state(
-        {"dryer": {"applianceState": "running", "currentPhase": "drying"}}
+        {"dryer": {"applianceState": "running", "currentPhase": "dry"}}
     )
     assert dryer.get_machine_state() == MachineState.RunningMainCycle
     assert dryer.get_cycle_status_drying() is True
+
+
+def test_end_state_maps_to_complete() -> None:
+    dryer = _make_dryer()
+    dryer.update_state({"dryer": {"applianceState": "end"}})
+    assert dryer.get_machine_state() == MachineState.Complete

--- a/tests/awsiot/test_dryer.py
+++ b/tests/awsiot/test_dryer.py
@@ -1,0 +1,74 @@
+"""Tests for the AWS IoT Dryer class."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from whirlpool.awsiot.dryer import Dryer
+from whirlpool.dryer import Dryness, MachineState, WrinkleShield
+from whirlpool.types import ApplianceInfo
+
+_STATE = json.loads(
+    (Path(__file__).parent.parent / "data" / "awsiot" / "dryer_state.json").read_text()
+)
+
+
+def _make_dryer() -> Dryer:
+    mqtt = MagicMock()
+    mqtt.client_id = "client"
+    info = ApplianceInfo(
+        said="WPR1D00000002",
+        name="dryer",
+        category="laundry",
+        model_number="MGD7020RF0",
+        serial_number="S",
+    )
+    dryer = Dryer(mqtt, info)
+    dryer.update_state(_STATE)
+    return dryer
+
+
+def test_machine_state_standby() -> None:
+    assert _make_dryer().get_machine_state() == MachineState.Standby
+
+
+def test_door_closed() -> None:
+    assert _make_dryer().get_door_open() is False
+
+
+def test_time_remaining() -> None:
+    assert _make_dryer().get_time_remaining() == 2185
+
+
+def test_drum_light_off() -> None:
+    assert _make_dryer().get_drum_light_on() is False
+
+
+def test_cycle_status_flags_false_in_standby() -> None:
+    dryer = _make_dryer()
+    assert dryer.get_cycle_status_airflow_status() is False
+    assert dryer.get_cycle_status_cool_down() is False
+    assert dryer.get_cycle_status_damp() is False
+    assert dryer.get_cycle_status_drying() is False
+    assert dryer.get_cycle_status_limited_cycle() is False
+    assert dryer.get_cycle_status_sensing() is False
+    assert dryer.get_cycle_status_static_reduce() is False
+    assert dryer.get_cycle_status_steaming() is False
+    assert dryer.get_cycle_status_wet() is False
+
+
+def test_wrinkle_shield_off() -> None:
+    assert _make_dryer().get_wrinkle_shield() == WrinkleShield.Off
+
+
+def test_dryness_decodes_known_level() -> None:
+    assert _make_dryer().get_dryness() == Dryness.Normal
+
+
+def test_running_cycle_reports_phase_and_state() -> None:
+    dryer = _make_dryer()
+    dryer.update_state(
+        {"dryer": {"applianceState": "running", "currentPhase": "drying"}}
+    )
+    assert dryer.get_machine_state() == MachineState.RunningMainCycle
+    assert dryer.get_cycle_status_drying() is True

--- a/tests/awsiot/test_washer.py
+++ b/tests/awsiot/test_washer.py
@@ -1,0 +1,61 @@
+"""Tests for the AWS IoT Washer class."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from whirlpool.awsiot.washer import Washer
+from whirlpool.types import ApplianceInfo
+from whirlpool.washer import MachineState
+
+_STATE = json.loads(
+    (Path(__file__).parent.parent / "data" / "awsiot" / "washer_state.json").read_text()
+)
+
+
+def _make_washer() -> Washer:
+    mqtt = MagicMock()
+    mqtt.client_id = "client"
+    info = ApplianceInfo(
+        said="WPR1W00000001",
+        name="washer",
+        category="laundry",
+        model_number="MFW7020RF0",
+        serial_number="S",
+    )
+    washer = Washer(mqtt, info)
+    washer.update_state(_STATE)
+    return washer
+
+
+def test_machine_state_standby() -> None:
+    assert _make_washer().get_machine_state() == MachineState.Standby
+
+
+def test_door_closed() -> None:
+    assert _make_washer().get_door_open() is False
+
+
+def test_time_remaining() -> None:
+    assert _make_washer().get_time_remaining() == 5351
+
+
+def test_cycle_status_flags_false_in_standby() -> None:
+    washer = _make_washer()
+    assert washer.get_cycle_status_sensing() is False
+    assert washer.get_cycle_status_filling() is False
+    assert washer.get_cycle_status_soaking() is False
+    assert washer.get_cycle_status_washing() is False
+    assert washer.get_cycle_status_rinsing() is False
+    assert washer.get_cycle_status_spinning() is False
+
+
+def test_running_cycle_reports_phase_and_state() -> None:
+    washer = _make_washer()
+    washer.update_state(
+        {"washer": {"applianceState": "running", "currentPhase": "washing"}}
+    )
+    assert washer.get_machine_state() == MachineState.RunningMainCycle
+    assert washer.get_cycle_status_washing() is True
+    # The other phases must remain false.
+    assert washer.get_cycle_status_rinsing() is False

--- a/tests/awsiot/test_washer.py
+++ b/tests/awsiot/test_washer.py
@@ -57,9 +57,15 @@ def test_cycle_status_flags_false_in_standby() -> None:
 def test_running_cycle_reports_phase_and_state() -> None:
     washer = _make_washer()
     washer.update_state(
-        {"washer": {"applianceState": "running", "currentPhase": "washing"}}
+        {"washer": {"applianceState": "running", "currentPhase": "wash"}}
     )
     assert washer.get_machine_state() == MachineState.RunningMainCycle
     assert washer.get_cycle_status_washing() is True
     # The other phases must remain false.
     assert washer.get_cycle_status_rinsing() is False
+
+
+def test_end_state_maps_to_complete() -> None:
+    washer = _make_washer()
+    washer.update_state({"washer": {"applianceState": "end"}})
+    assert washer.get_machine_state() == MachineState.Complete

--- a/tests/awsiot/test_washer.py
+++ b/tests/awsiot/test_washer.py
@@ -40,6 +40,10 @@ def test_time_remaining() -> None:
     assert _make_washer().get_time_remaining() == 5351
 
 
+def test_cycle_time_complete() -> None:
+    assert _make_washer().get_cycle_time_complete() == 1783898525
+
+
 def test_cycle_status_flags_false_in_standby() -> None:
     washer = _make_washer()
     assert washer.get_cycle_status_sensing() is False

--- a/tests/data/awsiot/dryer_state.json
+++ b/tests/data/awsiot/dryer_state.json
@@ -1,0 +1,37 @@
+{
+  "dryer": {
+    "applianceState": "standby",
+    "cycleName": "normal",
+    "cycleType": "standard",
+    "specialName": "",
+    "currentPhase": "",
+    "dryLevel": "normalDry",
+    "dryTemperature": "medium",
+    "wrinkleShield": "off",
+    "steam": "off",
+    "staticGuardEnable": "on",
+    "dampDry": "off",
+    "extraPower": "off",
+    "pets": "off",
+    "cycleTime": {
+      "state": "idle",
+      "time": 2185,
+      "timeComplete": 1783895096,
+      "timePaused": 1782146384
+    },
+    "sessionId": "",
+    "lowAirFlow": false,
+    "lintTrap": false,
+    "drumLight": false,
+    "doorStatus": "closed"
+  },
+  "remoteStartEnable": false,
+  "hmiControlLockout": false,
+  "faultHistory": ["F2E1", "none", "none", "none", "none"],
+  "activeFault": "none",
+  "sound": {
+    "cycleSignal": "max"
+  },
+  "capabilityPartNumber": "W11729930",
+  "systemVersion": "3.0.0"
+}

--- a/tests/data/awsiot/dryer_thing.json
+++ b/tests/data/awsiot/dryer_thing.json
@@ -1,0 +1,10 @@
+{
+  "thingName": "WPR1D00000002",
+  "thingTypeName": "MGD7020RF0",
+  "attributes": {
+    "Name": "4472796572",
+    "Category": "Laundry",
+    "Serial": "REDACTED",
+    "CapabilityPartNumber": "W11729930"
+  }
+}

--- a/tests/data/awsiot/washer_state.json
+++ b/tests/data/awsiot/washer_state.json
@@ -1,0 +1,42 @@
+{
+  "washer": {
+    "applianceState": "standby",
+    "cycleName": "normal",
+    "cycleType": "standard",
+    "specialName": "",
+    "currentPhase": "",
+    "soilLevel": "extraHeavy",
+    "washTemperature": "warm",
+    "spinSpeed": "medium",
+    "extraRinse": "off",
+    "postCare": "off",
+    "extraPower": "off",
+    "pets": "off",
+    "steam": "off",
+    "cycleTime": {
+      "state": "idle",
+      "time": 5351,
+      "timeComplete": 1783898525,
+      "timePaused": 1782754709
+    },
+    "delayTime": {
+      "state": "idle",
+      "time": 0,
+      "timeComplete": 0,
+      "timePaused": 0
+    },
+    "sessionId": "",
+    "cleanWasher": false,
+    "doorStatus": "closed",
+    "doorLockStatus": false
+  },
+  "remoteStartEnable": false,
+  "hmiControlLockout": false,
+  "faultHistory": ["F8E1", "none", "none", "none", "none"],
+  "activeFault": "none",
+  "sound": {
+    "cycleSignal": "max"
+  },
+  "capabilityPartNumber": "W11723751",
+  "systemVersion": "2.1.0"
+}

--- a/tests/data/awsiot/washer_thing.json
+++ b/tests/data/awsiot/washer_thing.json
@@ -1,0 +1,10 @@
+{
+  "thingName": "WPR1W00000001",
+  "thingTypeName": "MFW7020RF0",
+  "attributes": {
+    "Name": "776173686572",
+    "Category": "Laundry",
+    "Serial": "REDACTED",
+    "CapabilityPartNumber": "W11723751"
+  }
+}

--- a/whirlpool/awsiot/appliancesmanager.py
+++ b/whirlpool/awsiot/appliancesmanager.py
@@ -30,6 +30,18 @@ from .washer import Washer
 LOGGER = logging.getLogger(__name__)
 
 
+def _is_dryer_model(model_number: str) -> bool:
+    """Whether a laundry model number denotes a dryer.
+
+    Whirlpool/Maytag/KitchenAid laundry model numbers encode the product type
+    in the third character: "D" for dryers (e.g. MGD/MED/WGD/WED) and "W" for
+    washers (e.g. MFW/MHW/WFW/WTW). Used to split the ambiguous "laundry"
+    category, since both dryers and washers report category "laundry" on the
+    AWS IoT backend (see the Maytag MFW7020RF0 + MGD7020RF0 fixtures).
+    """
+    return len(model_number) >= 3 and model_number[2:3].upper() == "D"
+
+
 class AppliancesManager:
     def __init__(
         self,
@@ -160,6 +172,20 @@ class AppliancesManager:
                     parse_microwave_capability_profile(raw_capabilities),
                 )
                 self._microwaves[appliance_data.said] = appliance
+        elif appliance_data.category == "fabriccare":
+            appliance = Dryer(self._mqtt, appliance_data)
+            self._dryers[appliance_data.said] = appliance
+        elif appliance_data.category == "laundry":
+            # Both dryers and washers report category "laundry" on the AWS
+            # IoT backend, so disambiguate by model number. The third
+            # character of Whirlpool/Maytag/KitchenAid laundry model numbers
+            # encodes the product type (D = dryer, W = washer).
+            if _is_dryer_model(appliance_data.model_number):
+                appliance = Dryer(self._mqtt, appliance_data)
+                self._dryers[appliance_data.said] = appliance
+            else:
+                appliance = Washer(self._mqtt, appliance_data)
+                self._washers[appliance_data.said] = appliance
         if appliance is None:
             LOGGER.warning(
                 "Unsupported appliance category %s for %s",

--- a/whirlpool/awsiot/dryer.py
+++ b/whirlpool/awsiot/dryer.py
@@ -91,6 +91,10 @@ class Dryer(BaseDryer, Appliance):
         return self._get_path_int("dryer", "cycleTime", "time")
 
     @override
+    def get_cycle_time_complete(self) -> int | None:
+        return self._get_path_int("dryer", "cycleTime", "timeComplete")
+
+    @override
     def get_drum_light_on(self) -> bool | None:
         return self._get_path_bool("dryer", "drumLight")
 

--- a/whirlpool/awsiot/dryer.py
+++ b/whirlpool/awsiot/dryer.py
@@ -1,3 +1,12 @@
+"""Concrete awsiot Dryer — translates the MQTT state to the Dryer ABC.
+
+The AWS IoT state payload nests the laundry cavity under a `dryer` key and
+uses camelCase/attribute-style values (see `tests/data/awsiot/dryer_state.json`
+captured from a Maytag MGD7020RF0). Read-only accessors are grounded in that
+fixture; setters and capability-gated "changeable" flags are deferred until
+laundry capability profiles are available.
+"""
+
 from typing import override
 
 from ..dryer import Cycle, Dryness, MachineState, Temperature, WrinkleShield
@@ -5,6 +14,46 @@ from ..dryer import Dryer as BaseDryer
 from ..types import ApplianceInfo
 from .appliance import Appliance
 from .mqttclient import MqttClient
+
+# `dryer.applianceState` -> dryer MachineState. Only "standby" is confirmed
+# from a captured fixture (dryer at rest); the remaining values are inferred
+# from the HTTP API backend's state vocabulary and need confirmation against a
+# live running/complete capture.
+_MACHINE_STATE_MAP: dict[str, MachineState] = {
+    "standby": MachineState.Standby,
+    "idle": MachineState.Standby,
+    "setting": MachineState.Setting,
+    "delayCountdown": MachineState.DelayCountdownMode,
+    "delayPaused": MachineState.DelayPause,
+    "pause": MachineState.Pause,
+    "paused": MachineState.Pause,
+    "running": MachineState.RunningMainCycle,
+    "postCycle": MachineState.RunningPostCycle,
+    "complete": MachineState.Complete,
+    "completed": MachineState.Complete,
+    "exception": MachineState.Exceptions,
+    "exceptions": MachineState.Exceptions,
+    "powerFailure": MachineState.PowerFailure,
+    "cancelled": MachineState.Cancelled,
+}
+
+_WRINKLE_SHIELD_MAP: dict[str, WrinkleShield] = {
+    "off": WrinkleShield.Off,
+    "on": WrinkleShield.On,
+    "onWithSteam": WrinkleShield.OnWithSteam,
+}
+
+# `dryer.currentPhase` values used to derive the cycle status flags. Like the
+# washer phase vocabulary these are inferred pending a running-cycle capture.
+_PHASE_AIRFLOW = "airflow"
+_PHASE_COOL_DOWN = "coolDown"
+_PHASE_DAMP = "damp"
+_PHASE_DRYING = "drying"
+_PHASE_LIMITED_CYCLE = "limitedCycle"
+_PHASE_SENSING = "sensing"
+_PHASE_STATIC_REDUCE = "staticReduce"
+_PHASE_STEAMING = "steaming"
+_PHASE_WET = "wet"
 
 
 class Dryer(BaseDryer, Appliance):
@@ -15,118 +64,183 @@ class Dryer(BaseDryer, Appliance):
     ):
         super().__init__(mqttclient, appliance_info)
 
+    def _get_current_phase(self) -> str | None:
+        """Return the dryer's current phase string, or None when absent."""
+        return self._get_path_str("dryer", "currentPhase")
+
+    def _phase_is(self, phase: str) -> bool | None:
+        current = self._get_current_phase()
+        return None if current is None else current == phase
+
     @override
     def get_machine_state(self) -> MachineState | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "applianceState")
+        return _MACHINE_STATE_MAP.get(raw) if raw is not None else None
 
     @override
     def get_door_open(self) -> bool | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "doorStatus")
+        if raw == "open":
+            return True
+        if raw == "closed":
+            return False
+        return None
 
     @override
     def get_time_remaining(self) -> int | None:
-        raise NotImplementedError()
+        return self._get_path_int("dryer", "cycleTime", "time")
 
     @override
     def get_drum_light_on(self) -> bool | None:
-        raise NotImplementedError()
+        return self._get_path_bool("dryer", "drumLight")
+
+    # ------------------------------------------------------------------
+    # Capability-gated "changeable" flags.
+    #
+    # The HTTP API backend sourced these from `*_ChangeStatus*` state
+    # attributes. Under AWS IoT the equivalent signal is the appliance's
+    # capability profile (the microwave backend's "supports_X" pattern), which
+    # isn't captured yet for laundry models. Return None (unknown) until the
+    # profiles are available.
+    # ------------------------------------------------------------------
 
     @override
     def get_extra_power_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_steam_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_cycle_changeable(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_dryness_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_manual_dry_time_changeable(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_static_guard_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_temperature_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_wrinkle_shield_changeable(self) -> bool | None:
-        raise NotImplementedError()
+        return None
+
+    # ------------------------------------------------------------------
+    # Current set values.
+    #
+    # `dryLevel`, `dryTemperature` and the named cycle use model-specific
+    # vocabularies that aren't confirmed yet; they're best-effort decoded and
+    # fall back to None for unrecognised values.
+    # ------------------------------------------------------------------
 
     @override
     def get_dryness(self) -> Dryness | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "dryLevel")
+        if raw is None:
+            return None
+        return {
+            "moreDry": Dryness.More,
+            "normalDry": Dryness.Normal,
+            "lessDry": Dryness.Less,
+            "dampDry": Dryness.Low,
+        }.get(raw)
 
     @override
     def get_manual_dry_time(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_cycle(self) -> Cycle | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "cycleName")
+        if raw is None:
+            return None
+        return {
+            "regular": Cycle.Regular,
+            "heavyDuty": Cycle.HeavyDuty,
+            "delicates": Cycle.Delicates,
+            "wrinkleControl": Cycle.WrinkleControl,
+            "bulkyItems": Cycle.BulkyItems,
+            "quickDry": Cycle.QuickDry,
+            "sanitize": Cycle.Sanitize,
+            "timedDry": Cycle.TimedDry,
+            "towels": Cycle.Towels,
+            "whites": Cycle.Whites,
+            "normal": Cycle.Normal,
+        }.get(raw)
 
     @override
     def get_cycle_status_airflow_status(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_AIRFLOW)
 
     @override
     def get_cycle_status_cool_down(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_COOL_DOWN)
 
     @override
     def get_cycle_status_damp(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_DAMP)
 
     @override
     def get_cycle_status_drying(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_DRYING)
 
     @override
     def get_cycle_status_limited_cycle(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_LIMITED_CYCLE)
 
     @override
     def get_cycle_status_sensing(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_SENSING)
 
     @override
     def get_cycle_status_static_reduce(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_STATIC_REDUCE)
 
     @override
     def get_cycle_status_steaming(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_STEAMING)
 
     @override
     def get_cycle_status_wet(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_WET)
 
     @override
     def get_cycle_count(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_damp_notification_tone_volume(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_alert_tone_volume(self) -> int | None:
-        raise NotImplementedError()
+        return None
 
     @override
     def get_temperature(self) -> Temperature | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "dryTemperature")
+        if raw is None:
+            return None
+        return {
+            "air": Temperature.Air,
+            "cool": Temperature.Cool,
+            "warm": Temperature.Warm,
+            "warmHigh": Temperature.WarmHigh,
+            "hot": Temperature.Hot,
+        }.get(raw)
 
     @override
     def get_wrinkle_shield(self) -> WrinkleShield | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("dryer", "wrinkleShield")
+        return _WRINKLE_SHIELD_MAP.get(raw) if raw is not None else None

--- a/whirlpool/awsiot/dryer.py
+++ b/whirlpool/awsiot/dryer.py
@@ -15,10 +15,10 @@ from ..types import ApplianceInfo
 from .appliance import Appliance
 from .mqttclient import MqttClient
 
-# `dryer.applianceState` -> dryer MachineState. Only "standby" is confirmed
-# from a captured fixture (dryer at rest); the remaining values are inferred
-# from the HTTP API backend's state vocabulary and need confirmation against a
-# live running/complete capture.
+# `dryer.applianceState` -> dryer MachineState. "standby", "running" and
+# "end" are confirmed from live captures (Maytag MGD7020RF0); the remaining
+# values are inferred from the HTTP API backend's state vocabulary and still
+# need confirmation against a live capture.
 _MACHINE_STATE_MAP: dict[str, MachineState] = {
     "standby": MachineState.Standby,
     "idle": MachineState.Standby,
@@ -31,6 +31,7 @@ _MACHINE_STATE_MAP: dict[str, MachineState] = {
     "postCycle": MachineState.RunningPostCycle,
     "complete": MachineState.Complete,
     "completed": MachineState.Complete,
+    "end": MachineState.Complete,
     "exception": MachineState.Exceptions,
     "exceptions": MachineState.Exceptions,
     "powerFailure": MachineState.PowerFailure,
@@ -43,12 +44,13 @@ _WRINKLE_SHIELD_MAP: dict[str, WrinkleShield] = {
     "onWithSteam": WrinkleShield.OnWithSteam,
 }
 
-# `dryer.currentPhase` values used to derive the cycle status flags. Like the
-# washer phase vocabulary these are inferred pending a running-cycle capture.
+# `dryer.currentPhase` values used to derive the cycle status flags. "dry"
+# is confirmed from a live running-cycle capture (Maytag MGD7020RF0); the
+# remaining spellings are inferred and still need confirmation.
 _PHASE_AIRFLOW = "airflow"
 _PHASE_COOL_DOWN = "coolDown"
 _PHASE_DAMP = "damp"
-_PHASE_DRYING = "drying"
+_PHASE_DRYING = "dry"
 _PHASE_LIMITED_CYCLE = "limitedCycle"
 _PHASE_SENSING = "sensing"
 _PHASE_STATIC_REDUCE = "staticReduce"

--- a/whirlpool/awsiot/washer.py
+++ b/whirlpool/awsiot/washer.py
@@ -110,3 +110,7 @@ class Washer(BaseWasher, Appliance):
     @override
     def get_time_remaining(self) -> int | None:
         return self._get_path_int("washer", "cycleTime", "time")
+
+    @override
+    def get_cycle_time_complete(self) -> int | None:
+        return self._get_path_int("washer", "cycleTime", "timeComplete")

--- a/whirlpool/awsiot/washer.py
+++ b/whirlpool/awsiot/washer.py
@@ -1,3 +1,12 @@
+"""Concrete awsiot Washer — translates the MQTT state to the Washer ABC.
+
+The AWS IoT state payload nests the laundry cavity under a `washer` key and
+uses camelCase/attribute-style values (see `tests/data/awsiot/washer_state.json`
+captured from a Maytag MFW7020RF0). The read-only accessors below decode that
+state; setters are intentionally absent until laundry capability profiles are
+available (the microwave backend is the reference for how that will work).
+"""
+
 from typing import override
 
 from ..types import ApplianceInfo
@@ -5,6 +14,37 @@ from ..washer import MachineState
 from ..washer import Washer as BaseWasher
 from .appliance import Appliance
 from .mqttclient import MqttClient
+
+# `washer.applianceState` -> washer MachineState. Only "standby" is confirmed
+# from a captured fixture (standby washer); the remaining values are inferred
+# from the HTTP API backend's state vocabulary and need confirmation against a
+# live running/complete capture before being relied upon.
+_MACHINE_STATE_MAP: dict[str, MachineState] = {
+    "standby": MachineState.Standby,
+    "idle": MachineState.Standby,
+    "setting": MachineState.Setting,
+    "delayCountdown": MachineState.DelayCountdownMode,
+    "delayPaused": MachineState.DelayPause,
+    "pause": MachineState.Pause,
+    "paused": MachineState.Pause,
+    "running": MachineState.RunningMainCycle,
+    "postCycle": MachineState.RunningPostCycle,
+    "complete": MachineState.Complete,
+    "completed": MachineState.Complete,
+    "exception": MachineState.Exceptions,
+    "exceptions": MachineState.Exceptions,
+    "powerFailure": MachineState.PowerFailure,
+}
+
+# `washer.currentPhase` values used to derive the cycle status flags. Like the
+# machine-state vocabulary these are inferred; a running-cycle capture would
+# confirm the exact spellings.
+_PHASE_SENSING = "sensing"
+_PHASE_FILLING = "filling"
+_PHASE_SOAKING = "soaking"
+_PHASE_WASHING = "washing"
+_PHASE_RINSING = "rinsing"
+_PHASE_SPINNING = "spinning"
 
 
 class Washer(BaseWasher, Appliance):
@@ -15,42 +55,58 @@ class Washer(BaseWasher, Appliance):
     ):
         super().__init__(mqttclient, appliance_info)
 
+    def _get_current_phase(self) -> str | None:
+        """Return the washer's current phase string, or None when absent."""
+        return self._get_path_str("washer", "currentPhase")
+
+    def _phase_is(self, phase: str) -> bool | None:
+        current = self._get_current_phase()
+        return None if current is None else current == phase
+
     @override
     def get_machine_state(self) -> MachineState | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("washer", "applianceState")
+        return _MACHINE_STATE_MAP.get(raw) if raw is not None else None
 
     @override
     def get_cycle_status_sensing(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_SENSING)
 
     @override
     def get_cycle_status_filling(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_FILLING)
 
     @override
     def get_cycle_status_soaking(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_SOAKING)
 
     @override
     def get_cycle_status_washing(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_WASHING)
 
     @override
     def get_cycle_status_rinsing(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_RINSING)
 
     @override
     def get_cycle_status_spinning(self) -> bool | None:
-        raise NotImplementedError()
+        return self._phase_is(_PHASE_SPINNING)
 
     @override
     def get_dispense_1_level(self) -> int | None:
-        raise NotImplementedError()
+        # No captured washer fixture exposes a bulk-dispense level yet;
+        # return None (unsupported/unknown) until a dispenser model is captured.
+        return None
 
     @override
     def get_door_open(self) -> bool | None:
-        raise NotImplementedError()
+        raw = self._get_path_str("washer", "doorStatus")
+        if raw == "open":
+            return True
+        if raw == "closed":
+            return False
+        return None
 
     @override
     def get_time_remaining(self) -> int | None:
-        raise NotImplementedError()
+        return self._get_path_int("washer", "cycleTime", "time")

--- a/whirlpool/awsiot/washer.py
+++ b/whirlpool/awsiot/washer.py
@@ -15,10 +15,10 @@ from ..washer import Washer as BaseWasher
 from .appliance import Appliance
 from .mqttclient import MqttClient
 
-# `washer.applianceState` -> washer MachineState. Only "standby" is confirmed
-# from a captured fixture (standby washer); the remaining values are inferred
-# from the HTTP API backend's state vocabulary and need confirmation against a
-# live running/complete capture before being relied upon.
+# `washer.applianceState` -> washer MachineState. "standby", "running" and
+# "end" are confirmed from live captures (Maytag MFW7020RF0); the remaining
+# values are inferred from the HTTP API backend's state vocabulary and still
+# need confirmation against a live capture.
 _MACHINE_STATE_MAP: dict[str, MachineState] = {
     "standby": MachineState.Standby,
     "idle": MachineState.Standby,
@@ -31,18 +31,19 @@ _MACHINE_STATE_MAP: dict[str, MachineState] = {
     "postCycle": MachineState.RunningPostCycle,
     "complete": MachineState.Complete,
     "completed": MachineState.Complete,
+    "end": MachineState.Complete,
     "exception": MachineState.Exceptions,
     "exceptions": MachineState.Exceptions,
     "powerFailure": MachineState.PowerFailure,
 }
 
-# `washer.currentPhase` values used to derive the cycle status flags. Like the
-# machine-state vocabulary these are inferred; a running-cycle capture would
-# confirm the exact spellings.
+# `washer.currentPhase` values used to derive the cycle status flags. "wash"
+# is confirmed from a live running-cycle capture (Maytag MFW7020RF0); the
+# remaining spellings are inferred and still need confirmation.
 _PHASE_SENSING = "sensing"
 _PHASE_FILLING = "filling"
 _PHASE_SOAKING = "soaking"
-_PHASE_WASHING = "washing"
+_PHASE_WASHING = "wash"
 _PHASE_RINSING = "rinsing"
 _PHASE_SPINNING = "spinning"
 

--- a/whirlpool/dryer.py
+++ b/whirlpool/dryer.py
@@ -79,6 +79,14 @@ class Dryer(Appliance, ABC):
     def get_time_remaining(self) -> int | None:
         pass
 
+    def get_cycle_time_complete(self) -> int | None:
+        """Return the Unix timestamp (seconds) of the last completed cycle.
+
+        Only the AWS IoT backend reports this field; other backends return
+        ``None``.
+        """
+        return None
+
     @abstractmethod
     def get_drum_light_on(self) -> bool | None:
         pass

--- a/whirlpool/washer.py
+++ b/whirlpool/washer.py
@@ -66,3 +66,11 @@ class Washer(Appliance, ABC):
     @abstractmethod
     def get_time_remaining(self) -> int | None:
         pass
+
+    def get_cycle_time_complete(self) -> int | None:
+        """Return the Unix timestamp (seconds) of the last completed cycle.
+
+        Only the AWS IoT backend reports this field; other backends return
+        ``None``.
+        """
+        return None


### PR DESCRIPTION
## What

Implements the read-only `Washer` and `Dryer` AWS IoT accessors so the newer backend reports machine state, door state, and time remaining for Maytag/Whirlpool laundry appliances.

## Why

Home Assistant's Whirlpool integration exposes `sensor.<name>_state` and `sensor.<name>_timeremaining`, but the AWS IoT backend (still unreleased in HA core) stubs every washer/dryer accessor with `NotImplementedError`.

## Change

- Ground `get_machine_state`, `get_door_open`, `get_time_remaining`, cycle phases, drum light, wrinkle shield, dryness, cycle, and temperature on the `washer.` / `dryer.` MQTT state keys, using the MFW7020RF0 washer + MGD7020RF0 dryer fixtures captured in #138.
- Restore `laundry`-category routing removed in #164: both washers and dryers report category `"laundry"` on this backend, so split by model number (third character `D`/`W`, as in #139) pending capability-based routing.
- Reinstate `fabriccare` → `Dryer`.
- Add fixtures and tests for washer, dryer, and laundry routing.

## Limitations

Machine-state and cycle-phase string vocabularies beyond `"standby"` are inferred from structure and need confirmation against a live running-cycle capture. Capability files (`W11723751` washer, `W11729930` dryer) are still required to move routing off the model-number heuristic.
